### PR TITLE
feat: add SMART request layer over KLAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Many other TP-Link Plug and Bulb models may work as well. Note that Tapo devices
 - For child channels that expose brightness in child sysinfo (for example dimmer + fan combinations), dimmer capability is detected from child data when a `childId` is selected.
 - This project primarily targets the legacy TP-Link Smart Home protocol (`IOT.*` on port `9999`), and now includes an experimental `klap` transport for authenticated `/app/*` sessions (credential or `credentialsHash` based).
 - The `klap` transport currently enables low-level transport/session handling (`client.send` / `device.send`) but does not provide full SMART module parity or AES transport support yet.
+- For SMART requests over KLAP, use `client.sendSmart(...)`, `device.sendSmartCommand(...)`, and `device.sendSmartRequests(...)` (including child-scoped `control_child` wrapping).
 - As a result, model names like `KS240` are still not automatically equivalent to full high-level feature support in this library.
 
 ## Related Projects
@@ -65,6 +66,21 @@ Install the command line utility with `npm install -g tplink-smarthome-api`. Run
 For functions that send commands, the last argument is `SendOptions` where you can set the `transport` (`'tcp'`, `'udp'`, `'klap'`) and `timeout`, etc.
 
 Functions that take more than 3 arguments are passed a single options object as the first argument (and if its a network command, SendOptions as the second.)
+
+Example SMART over KLAP:
+
+```javascript
+const client = new Client({
+  credentials: { username: 'user@example.com', password: 'secret' },
+});
+
+const device = client.getPlug({ host: '10.0.1.2', sysInfo });
+const info = await device.sendSmartCommand('get_device_info');
+const multi = await device.sendSmartRequests([
+  { method: 'get_device_info' },
+  { method: 'get_device_time' },
+]);
+```
 
 ## Credits
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,8 @@ export {
   type DiscoveryDevice,
   type DiscoveryOptions,
   type SendOptions,
+  type SmartMethodRequest,
+  type SmartRequestPayload,
 } from './client';
 
 export {
@@ -36,6 +38,7 @@ export {
   type CommonSysinfo,
   type DeviceConstructorOptions,
   type DeviceEvents,
+  type SmartMethodResponseMap,
   type Sysinfo,
 } from './device';
 export type { default as Netif } from './device/netif';
@@ -87,4 +90,5 @@ export type { default as Time } from './shared/time';
 export type { LogLevelMethodNames, Logger } from './logger';
 export type { CredentialOptions, Credentials } from './credentials';
 
+export { default as SmartError } from './smart-error';
 export { ResponseError, type HasErrCode } from './utils';

--- a/src/smart-error.ts
+++ b/src/smart-error.ts
@@ -1,0 +1,24 @@
+/**
+ * Represents an error result received from a TP-Link SMART response.
+ *
+ * Where response `error_code` != `0`.
+ */
+export default class SmartError extends Error {
+  /**
+   * Set by `Error.captureStackTrace`
+   */
+  override readonly stack = '';
+
+  constructor(
+    message: string,
+    readonly errorCode: number,
+    readonly method: string,
+    readonly response: string,
+    readonly request: string,
+  ) {
+    super(message);
+    this.name = 'SmartError';
+    this.message = `${message} error_code: ${errorCode} method: ${method} response: ${response} request: ${request}`;
+    Error.captureStackTrace(this, this.constructor);
+  }
+}


### PR DESCRIPTION
## Summary\n- add SMART request APIs over KLAP (client.sendSmart, device.sendSmartCommand, device.sendSmartRequests)\n- add child-scoped control_child request wrapping + response unwrapping\n- add SMART error handling via exported SmartError\n- add SMART-over-KLAP test coverage and README docs\n\n## Validation\n- npm run build\n- npm run test:only -- test/network/klap-connection.js\n