### PR TITLE
feat: add AES securePassthrough transport with SMART support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,8 @@ Many other TP-Link Plug and Bulb models may work as well. Note that Tapo devices
 
 - Child-scoped operations (`childId`) are supported for plug modules such as `away`, `schedule`, `timer`, `emeter`, and `dimmer`.
 - For child channels that expose brightness in child sysinfo (for example dimmer + fan combinations), dimmer capability is detected from child data when a `childId` is selected.
-- This project primarily targets the legacy TP-Link Smart Home protocol (`IOT.*` on port `9999`), and now includes an experimental `klap` transport for authenticated `/app/*` sessions (credential or `credentialsHash` based).
-- The `klap` transport currently enables low-level transport/session handling (`client.send` / `device.send`) but does not provide full SMART module parity or AES transport support yet.
-- For SMART requests over KLAP, use `client.sendSmart(...)`, `device.sendSmartCommand(...)`, and `device.sendSmartRequests(...)` (including child-scoped `control_child` wrapping).
+- This project primarily targets the legacy TP-Link Smart Home protocol (`IOT.*` on port `9999`), and now includes experimental authenticated HTTP transports: `klap` and `aes` (credential or `credentialsHash` based).
+- For SMART requests over authenticated transports, use `client.sendSmart(...)`, `device.sendSmartCommand(...)`, and `device.sendSmartRequests(...)` (including child-scoped `control_child` wrapping).
 - As a result, model names like `KS240` are still not automatically equivalent to full high-level feature support in this library.
 
 ## Related Projects
@@ -63,7 +62,7 @@ Install the command line utility with `npm install -g tplink-smarthome-api`. Run
 
 [API docs can be found here.](https://plasticrake.github.io/tplink-smarthome-api/)
 
-For functions that send commands, the last argument is `SendOptions` where you can set the `transport` (`'tcp'`, `'udp'`, `'klap'`) and `timeout`, etc.
+For functions that send commands, the last argument is `SendOptions` where you can set the `transport` (`'tcp'`, `'udp'`, `'klap'`, `'aes'`) and `timeout`, etc.
 
 Functions that take more than 3 arguments are passed a single options object as the first argument (and if its a network command, SendOptions as the second.)
 

--- a/src/network/aes-connection.ts
+++ b/src/network/aes-connection.ts
@@ -1,0 +1,712 @@
+import {
+  constants,
+  createCipheriv,
+  createDecipheriv,
+  createHash,
+  generateKeyPairSync,
+  privateDecrypt,
+} from 'crypto';
+import http, { type IncomingHttpHeaders } from 'http';
+import https from 'https';
+import Queue from 'promise-queue';
+
+import type Client from '../client';
+import {
+  type CredentialOptions,
+  type Credentials,
+  normalizeCredentialOptions,
+} from '../credentials';
+import type { Logger } from '../logger';
+import type { ConnectionSendOptions, DeviceConnection } from './connection';
+
+type AesHttpResponse = {
+  statusCode: number;
+  body: string;
+  headers: IncomingHttpHeaders;
+};
+
+type AesRequestOptions = {
+  headers?: Record<string, string>;
+  cookie?: string;
+};
+
+type AesStatusError = Error & {
+  statusCode?: number;
+  errorCode?: number;
+};
+
+type AesEncryptionSession = {
+  key: Buffer;
+  iv: Buffer;
+};
+
+type AesLoginParams = {
+  username: string;
+  password?: string;
+  password2?: string;
+};
+
+type AesLoginCandidate = {
+  label: string;
+  params: AesLoginParams;
+};
+
+const ONE_DAY_SECONDS = 86400;
+const SESSION_EXPIRE_BUFFER_SECONDS = 60 * 20;
+const SESSION_COOKIE_NAME = 'TP_SESSIONID';
+const SESSION_COOKIE_NAME_FALLBACK = 'SESSIONID';
+const TIMEOUT_COOKIE_NAME = 'TIMEOUT';
+const AES_PROTOCOL_PATH = '/app';
+
+const AES_AUTH_ERROR_CODES = new Set([
+  -1501, // LOGIN_ERROR
+  1111, // LOGIN_FAILED_ERROR
+  -1005, // AES_DECODE_FAIL_ERROR
+  1100, // HAND_SHAKE_FAILED_ERROR
+  1003, // TRANSPORT_UNKNOWN_CREDENTIALS_ERROR
+  -40412, // HOMEKIT_LOGIN_FAIL
+]);
+
+const DEFAULT_TAPO_CREDENTIAL_BASE64 = {
+  username: 'dGVzdEB0cC1saW5rLm5ldA==',
+  password: 'dGVzdA==',
+};
+
+function decodeBase64(value: string): string {
+  return Buffer.from(value, 'base64').toString('utf8');
+}
+
+function parseSetCookie(headers: IncomingHttpHeaders): string[] {
+  if (headers['set-cookie'] == null) return [];
+  if (Array.isArray(headers['set-cookie'])) return headers['set-cookie'];
+  return [headers['set-cookie']];
+}
+
+function getCookieValue(cookies: string[], name: string): string | undefined {
+  for (const cookie of cookies) {
+    const firstEntry = cookie.split(';')[0];
+    if (firstEntry !== undefined) {
+      const [cookieName, cookieValue] = firstEntry.split('=');
+      if (cookieName === name && cookieValue !== undefined) {
+        return cookieValue;
+      }
+    }
+  }
+  return undefined;
+}
+
+function isObjectLike(
+  candidate: unknown,
+): candidate is Record<string, unknown> {
+  return typeof candidate === 'object' && candidate !== null;
+}
+
+function sha1Hex(payload: string): string {
+  return createHash('sha1').update(payload, 'utf8').digest('hex');
+}
+
+function base64EncodeString(payload: string): string {
+  return Buffer.from(payload, 'utf8').toString('base64');
+}
+
+function encryptAesPayload(
+  session: AesEncryptionSession,
+  payload: string,
+): string {
+  const cipher = createCipheriv('aes-128-cbc', session.key, session.iv);
+  const encrypted = Buffer.concat([
+    cipher.update(Buffer.from(payload, 'utf8')),
+    cipher.final(),
+  ]);
+  return encrypted.toString('base64');
+}
+
+function decryptAesPayload(
+  session: AesEncryptionSession,
+  payload: string,
+): string {
+  const decipher = createDecipheriv('aes-128-cbc', session.key, session.iv);
+  const decrypted = Buffer.concat([
+    decipher.update(Buffer.from(payload, 'base64')),
+    decipher.final(),
+  ]);
+  return decrypted.toString('utf8');
+}
+
+function decryptPkcs1v15(
+  privateKeyPem: string,
+  encryptedPayload: Buffer,
+): Buffer {
+  const decryptedBlock = privateDecrypt(
+    {
+      key: privateKeyPem,
+      padding: constants.RSA_NO_PADDING,
+    },
+    encryptedPayload,
+  );
+  if (decryptedBlock.length < 11) {
+    throw new Error('PKCS#1 block too short');
+  }
+  if (decryptedBlock[0] !== 0x00 || decryptedBlock[1] !== 0x02) {
+    throw new Error('Invalid PKCS#1 block prefix');
+  }
+
+  let separatorIndex = -1;
+  for (let index = 2; index < decryptedBlock.length; index += 1) {
+    if (decryptedBlock[index] === 0x00) {
+      separatorIndex = index;
+      break;
+    }
+  }
+  if (separatorIndex < 10) {
+    throw new Error('Invalid PKCS#1 padding length');
+  }
+
+  return decryptedBlock.subarray(separatorIndex + 1);
+}
+
+/**
+ * @hidden
+ */
+export default class AesConnection implements DeviceConnection {
+  private readonly queue = new Queue(1, Infinity);
+
+  private readonly credentials?: Credentials;
+
+  private readonly credentialsHash?: string;
+
+  private session?: AesEncryptionSession;
+
+  private sessionCookie?: string;
+
+  private sessionExpiresAt = 0;
+
+  private token?: string;
+
+  constructor(
+    public host: string,
+    public port: number,
+    readonly log: Logger,
+    readonly client: Client,
+    credentialOptions?: CredentialOptions,
+  ) {
+    const normalizedCredentials = normalizeCredentialOptions(
+      credentialOptions,
+      'aes connection credentials',
+    );
+    this.credentials = normalizedCredentials.credentials;
+    this.credentialsHash = normalizedCredentials.credentialsHash;
+  }
+
+  private get description(): string {
+    return `AES ${this.host}:${this.port}`;
+  }
+
+  private resetSession(): void {
+    this.session = undefined;
+    this.sessionCookie = undefined;
+    this.sessionExpiresAt = 0;
+    this.token = undefined;
+  }
+
+  private isSessionExpired(): boolean {
+    return this.sessionExpiresAt === 0 || Date.now() >= this.sessionExpiresAt;
+  }
+
+  private static hashLoginCredentials(
+    loginV2: boolean,
+    credentials: Credentials,
+  ): AesLoginParams {
+    const username = base64EncodeString(sha1Hex(credentials.username));
+    if (loginV2) {
+      return {
+        username,
+        password2: base64EncodeString(sha1Hex(credentials.password)),
+      };
+    }
+    return {
+      username,
+      password: base64EncodeString(credentials.password),
+    };
+  }
+
+  private static parseCredentialsHash(credentialsHash: string): AesLoginParams {
+    let decoded: string;
+    try {
+      decoded = Buffer.from(credentialsHash, 'base64').toString('utf8');
+    } catch {
+      throw new TypeError(
+        'credentialsHash must be base64-encoded AES login params JSON for aes transport',
+      );
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(decoded);
+    } catch {
+      throw new TypeError(
+        'credentialsHash must be base64-encoded AES login params JSON for aes transport',
+      );
+    }
+    if (!isObjectLike(parsed) || typeof parsed.username !== 'string') {
+      throw new TypeError(
+        'credentialsHash decoded AES login params must include username',
+      );
+    }
+    if (
+      typeof parsed.password !== 'string' &&
+      typeof parsed.password2 !== 'string'
+    ) {
+      throw new TypeError(
+        'credentialsHash decoded AES login params must include password or password2',
+      );
+    }
+    return {
+      username: parsed.username,
+      ...(typeof parsed.password === 'string'
+        ? { password: parsed.password }
+        : {}),
+      ...(typeof parsed.password2 === 'string'
+        ? { password2: parsed.password2 }
+        : {}),
+    };
+  }
+
+  private buildLoginCandidates(): AesLoginCandidate[] {
+    const candidates: AesLoginCandidate[] = [];
+    const seen = new Set<string>();
+    const addCandidate = (label: string, params: AesLoginParams): void => {
+      const key = JSON.stringify(params);
+      if (!seen.has(key)) {
+        seen.add(key);
+        candidates.push({ label, params });
+      }
+    };
+
+    if (this.credentialsHash !== undefined) {
+      addCandidate(
+        'credentialsHash',
+        AesConnection.parseCredentialsHash(this.credentialsHash),
+      );
+    }
+
+    if (this.credentials != null) {
+      addCandidate(
+        'credentials-v2',
+        AesConnection.hashLoginCredentials(true, this.credentials),
+      );
+      addCandidate(
+        'credentials-v1',
+        AesConnection.hashLoginCredentials(false, this.credentials),
+      );
+    }
+
+    const defaultTapoCredentials: Credentials = {
+      username: decodeBase64(DEFAULT_TAPO_CREDENTIAL_BASE64.username),
+      password: decodeBase64(DEFAULT_TAPO_CREDENTIAL_BASE64.password),
+    };
+    addCandidate(
+      'default-tapo-v2',
+      AesConnection.hashLoginCredentials(true, defaultTapoCredentials),
+    );
+    addCandidate(
+      'default-tapo-v1',
+      AesConnection.hashLoginCredentials(false, defaultTapoCredentials),
+    );
+
+    return candidates;
+  }
+
+  private static extractErrorCode(error: unknown): number | undefined {
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'errorCode' in error &&
+      typeof (error as AesStatusError).errorCode === 'number'
+    ) {
+      return (error as AesStatusError).errorCode;
+    }
+    return undefined;
+  }
+
+  private static extractStatusCode(error: unknown): number | undefined {
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'statusCode' in error &&
+      typeof (error as AesStatusError).statusCode === 'number'
+    ) {
+      return (error as AesStatusError).statusCode;
+    }
+    return undefined;
+  }
+
+  private assertResponseSuccess(
+    response: unknown,
+    context: string,
+  ): Record<string, unknown> {
+    if (!isObjectLike(response) || typeof response.error_code !== 'number') {
+      throw new Error(
+        `AesConnection(${this.description}): unexpected ${context} response`,
+      );
+    }
+
+    if (response.error_code !== 0) {
+      const error: AesStatusError = new Error(
+        `AesConnection(${this.description}): ${context} failed with error_code ${response.error_code}`,
+      );
+      error.errorCode = response.error_code;
+      if (AES_AUTH_ERROR_CODES.has(response.error_code)) {
+        this.resetSession();
+      }
+      throw error;
+    }
+    return response;
+  }
+
+  private async performHandshake(timeout: number): Promise<void> {
+    this.resetSession();
+
+    const { publicKey, privateKey } = generateKeyPairSync('rsa', {
+      modulusLength: 1024,
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    });
+
+    const handshakeResponse = await this.post(
+      AES_PROTOCOL_PATH,
+      JSON.stringify({
+        method: 'handshake',
+        params: { key: publicKey },
+      }),
+      timeout,
+      {
+        headers: {
+          requestByApp: 'true',
+          Accept: 'application/json',
+        },
+      },
+    );
+
+    if (handshakeResponse.statusCode !== 200) {
+      throw new Error(
+        `AesConnection(${this.description}): handshake failed with status ${handshakeResponse.statusCode}`,
+      );
+    }
+
+    const parsedResponse: unknown = JSON.parse(handshakeResponse.body);
+    const handshakeResult = this.assertResponseSuccess(
+      parsedResponse,
+      'handshake',
+    );
+    if (
+      !isObjectLike(handshakeResult.result) ||
+      typeof handshakeResult.result.key !== 'string'
+    ) {
+      throw new Error(
+        `AesConnection(${this.description}): handshake response is invalid`,
+      );
+    }
+
+    const unpaddedKeyMaterial = decryptPkcs1v15(
+      privateKey,
+      Buffer.from(handshakeResult.result.key, 'base64'),
+    );
+    if (unpaddedKeyMaterial.length < 32) {
+      throw new Error(
+        `AesConnection(${this.description}): handshake key material is invalid`,
+      );
+    }
+
+    this.session = {
+      key: unpaddedKeyMaterial.subarray(0, 16),
+      iv: unpaddedKeyMaterial.subarray(16, 32),
+    };
+
+    const setCookies = parseSetCookie(handshakeResponse.headers);
+    const timeoutCookie = getCookieValue(setCookies, TIMEOUT_COOKIE_NAME);
+    const timeoutSeconds =
+      timeoutCookie !== undefined
+        ? parseInt(timeoutCookie, 10)
+        : ONE_DAY_SECONDS;
+    const sessionId =
+      getCookieValue(setCookies, SESSION_COOKIE_NAME) ??
+      getCookieValue(setCookies, SESSION_COOKIE_NAME_FALLBACK);
+    this.sessionCookie =
+      sessionId !== undefined
+        ? `${SESSION_COOKIE_NAME}=${sessionId}`
+        : undefined;
+
+    const adjustedSessionSeconds = Math.max(
+      1,
+      (Number.isNaN(timeoutSeconds) ? ONE_DAY_SECONDS : timeoutSeconds) -
+        SESSION_EXPIRE_BUFFER_SECONDS,
+    );
+    this.sessionExpiresAt = Date.now() + adjustedSessionSeconds * 1000;
+  }
+
+  private async tryLogin(
+    loginParams: AesLoginParams,
+    timeout: number,
+  ): Promise<void> {
+    const loginResponse = await this.sendSecurePassthrough(
+      JSON.stringify({
+        method: 'login_device',
+        params: loginParams,
+        request_time_milis: Date.now(),
+      }),
+      timeout,
+    );
+
+    const loginResult = this.assertResponseSuccess(loginResponse, 'login');
+    if (
+      !isObjectLike(loginResult.result) ||
+      typeof loginResult.result.token !== 'string'
+    ) {
+      throw new Error(
+        `AesConnection(${this.description}): login response missing token`,
+      );
+    }
+    this.token = loginResult.result.token;
+  }
+
+  private async performLogin(timeout: number): Promise<void> {
+    const loginCandidates = this.buildLoginCandidates();
+    if (loginCandidates.length === 0) {
+      throw new Error(
+        `AesConnection(${this.description}): no login candidates available`,
+      );
+    }
+
+    await this.performLoginForCandidate(loginCandidates, timeout, 0);
+  }
+
+  private async performLoginForCandidate(
+    candidates: AesLoginCandidate[],
+    timeout: number,
+    index: number,
+  ): Promise<void> {
+    const candidate = candidates[index];
+    if (candidate === undefined) {
+      throw new Error(
+        `AesConnection(${this.description}): no login candidates succeeded`,
+      );
+    }
+
+    try {
+      await this.tryLogin(candidate.params, timeout);
+      this.log.debug(
+        'AesConnection(%s): authenticated with %s',
+        this.description,
+        candidate.label,
+      );
+    } catch (error) {
+      const errorCode = AesConnection.extractErrorCode(error);
+      if (
+        errorCode !== undefined &&
+        AES_AUTH_ERROR_CODES.has(errorCode) &&
+        index < candidates.length - 1
+      ) {
+        await this.performHandshake(timeout);
+        await this.performLoginForCandidate(candidates, timeout, index + 1);
+      }
+      throw error;
+    }
+  }
+
+  private async ensureSession(timeout: number): Promise<void> {
+    if (
+      this.session !== undefined &&
+      this.token !== undefined &&
+      !this.isSessionExpired()
+    ) {
+      return;
+    }
+
+    await this.performHandshake(timeout);
+    await this.performLogin(timeout);
+  }
+
+  private async sendSecurePassthrough(
+    payload: string,
+    timeout: number,
+  ): Promise<unknown> {
+    if (this.session === undefined) {
+      throw new Error(
+        `AesConnection(${this.description}): session is not initialized`,
+      );
+    }
+
+    const encryptedPayload = encryptAesPayload(this.session, payload);
+    const path =
+      this.token !== undefined
+        ? `${AES_PROTOCOL_PATH}?token=${encodeURIComponent(this.token)}`
+        : AES_PROTOCOL_PATH;
+
+    const response = await this.post(
+      path,
+      JSON.stringify({
+        method: 'securePassthrough',
+        params: { request: encryptedPayload },
+      }),
+      timeout,
+      {
+        headers: {
+          requestByApp: 'true',
+          Accept: 'application/json',
+        },
+        cookie: this.sessionCookie,
+      },
+    );
+
+    if (response.statusCode === 403) {
+      const error: AesStatusError = new Error(
+        `AesConnection(${this.description}): request rejected with 403`,
+      );
+      error.statusCode = 403;
+      this.resetSession();
+      throw error;
+    }
+    if (response.statusCode !== 200) {
+      throw new Error(
+        `AesConnection(${this.description}): request failed with status ${response.statusCode}`,
+      );
+    }
+
+    const parsedResponse: unknown = JSON.parse(response.body);
+    const passthroughResponse = this.assertResponseSuccess(
+      parsedResponse,
+      'securePassthrough',
+    );
+    if (
+      !isObjectLike(passthroughResponse.result) ||
+      typeof passthroughResponse.result.response !== 'string'
+    ) {
+      throw new Error(
+        `AesConnection(${this.description}): securePassthrough response payload is invalid`,
+      );
+    }
+
+    try {
+      const decryptedResponse = decryptAesPayload(
+        this.session,
+        passthroughResponse.result.response,
+      );
+      const parsed: unknown = JSON.parse(decryptedResponse);
+      return parsed;
+    } catch {
+      const parsed: unknown = JSON.parse(passthroughResponse.result.response);
+      return parsed;
+    }
+  }
+
+  private isHttpsRequest(): boolean {
+    return this.port === 443 || this.port === 4433;
+  }
+
+  private async post(
+    path: string,
+    data: string,
+    timeout: number,
+    options: AesRequestOptions = {},
+  ): Promise<AesHttpResponse> {
+    const body = Buffer.from(data, 'utf8');
+    const headers: Record<string, string | number> = {
+      'Content-Type': 'application/json',
+      'Content-Length': body.length,
+      Connection: 'keep-alive',
+      ...options.headers,
+    };
+    if (options.cookie !== undefined) {
+      headers.Cookie = options.cookie;
+    }
+
+    return new Promise((resolve, reject) => {
+      const requestOptions: https.RequestOptions = {
+        host: this.host,
+        port: this.port,
+        method: 'POST',
+        path,
+        headers,
+      };
+      if (this.isHttpsRequest()) {
+        requestOptions.rejectUnauthorized = false;
+      }
+
+      const request = (this.isHttpsRequest() ? https : http).request(
+        requestOptions,
+        (response) => {
+          const chunks: Buffer[] = [];
+          response.on('data', (chunk: Buffer | string) => {
+            chunks.push(
+              typeof chunk === 'string' ? Buffer.from(chunk, 'utf8') : chunk,
+            );
+          });
+          response.on('end', () => {
+            resolve({
+              statusCode: response.statusCode ?? 0,
+              body: Buffer.concat(chunks).toString('utf8'),
+              headers: response.headers,
+            });
+          });
+        },
+      );
+
+      request.setTimeout(timeout, () => {
+        request.destroy(
+          new Error(
+            `AesConnection(${this.description}): timeout after ${timeout}ms`,
+          ),
+        );
+      });
+
+      request.on('error', (error) => {
+        reject(error);
+      });
+
+      request.write(body);
+      request.end();
+    });
+  }
+
+  async send(
+    payload: string,
+    port: number,
+    host: string,
+    options: ConnectionSendOptions,
+  ): Promise<string> {
+    this.host = host;
+    this.port = port;
+    const { timeout } = options;
+
+    return this.queue.add(() => this.sendWithRetry(payload, timeout, 0));
+  }
+
+  private async sendWithRetry(
+    payload: string,
+    timeout: number,
+    attempt: number,
+  ): Promise<string> {
+    try {
+      await this.ensureSession(timeout);
+      const response = await this.sendSecurePassthrough(payload, timeout);
+      return JSON.stringify(response);
+    } catch (error) {
+      const statusCode = AesConnection.extractStatusCode(error);
+      const errorCode = AesConnection.extractErrorCode(error);
+      if (
+        attempt === 0 &&
+        (statusCode === 403 ||
+          (errorCode !== undefined && AES_AUTH_ERROR_CODES.has(errorCode)))
+      ) {
+        this.resetSession();
+        return this.sendWithRetry(payload, timeout, 1);
+      }
+      throw error;
+    }
+  }
+
+  close(): void {
+    this.resetSession();
+  }
+}

--- a/test/network/aes-connection.js
+++ b/test/network/aes-connection.js
@@ -1,0 +1,421 @@
+const assert = require('assert');
+const crypto = require('crypto');
+const http = require('http');
+
+const { default: Client } = require('../../src/client');
+
+const DEFAULT_TIMEOUT_SECONDS = 86400;
+const SESSION_COOKIE_NAME = 'TP_SESSIONID';
+const TIMEOUT_COOKIE_NAME = 'TIMEOUT';
+
+function sha1Hex(payload) {
+  return crypto.createHash('sha1').update(payload).digest('hex');
+}
+
+function base64Encode(payload) {
+  return Buffer.from(payload, 'utf8').toString('base64');
+}
+
+function expectedLoginParams(username, password, loginVariant) {
+  const hashedUsername = base64Encode(sha1Hex(username));
+  if (loginVariant === 'v1') {
+    return { username: hashedUsername, password: base64Encode(password) };
+  }
+  return {
+    username: hashedUsername,
+    password2: base64Encode(sha1Hex(password)),
+  };
+}
+
+function createPlugSysInfo() {
+  return {
+    alias: 'Test Plug',
+    deviceId: 'test-device-id',
+    model: 'KS240(US)',
+    sw_ver: '1.0.0',
+    hw_ver: '1.0',
+    type: 'IOT.SMARTPLUGSWITCH',
+    mac: '00:11:22:33:44:55',
+    feature: 'TIM',
+    relay_state: 0,
+    led_off: 0,
+  };
+}
+
+function readBody(req) {
+  return new Promise((resolve) => {
+    const chunks = [];
+    req.on('data', (chunk) => chunks.push(chunk));
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+  });
+}
+
+function getCookieValue(req, name) {
+  const cookieHeader = req.headers.cookie;
+  if (!cookieHeader) return undefined;
+  const cookies = cookieHeader.split(';').map((entry) => entry.trim());
+  const pair = cookies.find((entry) => entry.startsWith(`${name}=`));
+  if (!pair) return undefined;
+  return pair.substring(name.length + 1);
+}
+
+function encryptPayload(session, payload) {
+  const cipher = crypto.createCipheriv('aes-128-cbc', session.key, session.iv);
+  return Buffer.concat([
+    cipher.update(Buffer.from(payload, 'utf8')),
+    cipher.final(),
+  ]).toString('base64');
+}
+
+function decryptPayload(session, payload) {
+  const decipher = crypto.createDecipheriv(
+    'aes-128-cbc',
+    session.key,
+    session.iv,
+  );
+  return Buffer.concat([
+    decipher.update(Buffer.from(payload, 'base64')),
+    decipher.final(),
+  ]).toString('utf8');
+}
+
+function createAesTestServer({
+  username = 'user@example.com',
+  password = 'secret',
+  loginVariant = 'v2',
+  timeoutSeconds = DEFAULT_TIMEOUT_SECONDS,
+  requestHandler,
+} = {}) {
+  const metrics = {
+    handshakeCount: 0,
+    passthroughCount: 0,
+    loginCount: 0,
+    requestCount: 0,
+  };
+  const requests = [];
+  const sessions = new Map();
+  const expectedLogin = expectedLoginParams(username, password, loginVariant);
+
+  const server = http.createServer(async (req, res) => {
+    const bodyString = await readBody(req);
+    let payload;
+    try {
+      payload = JSON.parse(bodyString);
+    } catch (_error) {
+      res.writeHead(400);
+      res.end();
+      return;
+    }
+
+    const requestUrl = new URL(req.url, 'http://127.0.0.1');
+    if (requestUrl.pathname !== '/app') {
+      res.writeHead(404);
+      res.end();
+      return;
+    }
+
+    if (payload.method === 'handshake') {
+      metrics.handshakeCount += 1;
+      if (
+        !payload.params ||
+        typeof payload.params !== 'object' ||
+        typeof payload.params.key !== 'string'
+      ) {
+        res.writeHead(400);
+        res.end();
+        return;
+      }
+
+      const sessionId = `sid-${metrics.handshakeCount}`;
+      const key = crypto.randomBytes(16);
+      const iv = crypto.randomBytes(16);
+      sessions.set(sessionId, { key, iv, token: undefined });
+
+      const encryptedKey = crypto
+        .publicEncrypt(
+          {
+            key: payload.params.key,
+            padding: crypto.constants.RSA_PKCS1_PADDING,
+          },
+          Buffer.concat([key, iv]),
+        )
+        .toString('base64');
+
+      res.writeHead(200, {
+        'Content-Type': 'application/json',
+        'Set-Cookie': [
+          `${SESSION_COOKIE_NAME}=${sessionId}; Path=/`,
+          `${TIMEOUT_COOKIE_NAME}=${timeoutSeconds}; Path=/`,
+        ],
+      });
+      res.end(JSON.stringify({ error_code: 0, result: { key: encryptedKey } }));
+      return;
+    }
+
+    if (payload.method !== 'securePassthrough') {
+      res.writeHead(404);
+      res.end();
+      return;
+    }
+
+    metrics.passthroughCount += 1;
+    const sessionId = getCookieValue(req, SESSION_COOKIE_NAME);
+    if (!sessionId || !sessions.has(sessionId)) {
+      res.writeHead(403);
+      res.end();
+      return;
+    }
+    const session = sessions.get(sessionId);
+
+    if (
+      !payload.params ||
+      typeof payload.params !== 'object' ||
+      typeof payload.params.request !== 'string'
+    ) {
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error_code: -1008 }));
+      return;
+    }
+
+    let decryptedRequest;
+    try {
+      decryptedRequest = decryptPayload(session, payload.params.request);
+    } catch (_error) {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error_code: -1005 }));
+      return;
+    }
+    requests.push(decryptedRequest);
+
+    let parsedRequest;
+    try {
+      parsedRequest = JSON.parse(decryptedRequest);
+    } catch (_error) {
+      parsedRequest = undefined;
+    }
+
+    let innerResponse;
+    if (parsedRequest && parsedRequest.method === 'login_device') {
+      metrics.loginCount += 1;
+      const loginParams = parsedRequest.params || {};
+      const validLogin =
+        loginParams.username === expectedLogin.username &&
+        ((loginVariant === 'v2' &&
+          loginParams.password2 === expectedLogin.password2) ||
+          (loginVariant === 'v1' &&
+            loginParams.password === expectedLogin.password));
+
+      if (validLogin) {
+        session.token = `token-${sessionId}`;
+        innerResponse = { error_code: 0, result: { token: session.token } };
+      } else {
+        innerResponse = { error_code: -1501 };
+      }
+    } else {
+      if (
+        session.token == null ||
+        requestUrl.searchParams.get('token') !== session.token
+      ) {
+        innerResponse = { error_code: -1501 };
+      } else if (typeof requestHandler === 'function') {
+        const customResponse = requestHandler(parsedRequest, decryptedRequest);
+        innerResponse =
+          customResponse === undefined
+            ? { error_code: 0, result: { ok: true } }
+            : customResponse;
+      } else {
+        innerResponse = { error_code: 0, result: { ok: true } };
+      }
+      metrics.requestCount += 1;
+    }
+
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(
+      JSON.stringify({
+        error_code: 0,
+        result: {
+          response: encryptPayload(session, JSON.stringify(innerResponse)),
+        },
+      }),
+    );
+  });
+
+  const start = () =>
+    new Promise((resolve) => {
+      server.listen(0, '127.0.0.1', () => {
+        resolve(server.address().port);
+      });
+    });
+  const stop = () =>
+    new Promise((resolve) => {
+      server.close(() => resolve());
+    });
+
+  return { metrics, requests, start, stop };
+}
+
+function createAesPlug(client, host, port) {
+  return client.getPlug({
+    host,
+    port,
+    sysInfo: createPlugSysInfo(),
+  });
+}
+
+describe('AesConnection', function () {
+  it('defaults device port to 80 when client transport is aes', function () {
+    const client = new Client({
+      credentials: { username: 'user@example.com', password: 'secret' },
+      defaultSendOptions: {
+        timeout: 1500,
+        transport: 'aes',
+      },
+    });
+    const device = client.getPlug({
+      host: '127.0.0.1',
+      sysInfo: createPlugSysInfo(),
+    });
+
+    assert.strictEqual(device.port, 80);
+    device.closeConnection();
+  });
+
+  it('reuses AES handshake/login session across sequential device.send calls', async function () {
+    const server = createAesTestServer();
+    const port = await server.start();
+    const client = new Client({
+      credentials: { username: 'user@example.com', password: 'secret' },
+      defaultSendOptions: { timeout: 1500, transport: 'aes' },
+    });
+    const device = createAesPlug(client, '127.0.0.1', port);
+
+    const first = await device.send('{"method":"first"}');
+    const second = await device.send('{"method":"second"}');
+
+    assert.deepStrictEqual(JSON.parse(first), {
+      error_code: 0,
+      result: { ok: true },
+    });
+    assert.deepStrictEqual(JSON.parse(second), {
+      error_code: 0,
+      result: { ok: true },
+    });
+    assert.strictEqual(server.metrics.handshakeCount, 1);
+    assert.strictEqual(server.metrics.loginCount, 1);
+    assert.strictEqual(server.metrics.requestCount, 2);
+
+    device.closeConnection();
+    await server.stop();
+  });
+
+  it('re-authenticates when AES session timeout expires', async function () {
+    const server = createAesTestServer({ timeoutSeconds: 1 });
+    const port = await server.start();
+    const client = new Client({
+      credentials: { username: 'user@example.com', password: 'secret' },
+      defaultSendOptions: { timeout: 1500, transport: 'aes' },
+    });
+    const device = createAesPlug(client, '127.0.0.1', port);
+
+    await device.send('{"method":"first"}');
+    await new Promise((resolve) => {
+      setTimeout(resolve, 1200);
+    });
+    await device.send('{"method":"second"}');
+
+    assert.strictEqual(server.metrics.handshakeCount, 2);
+    assert.strictEqual(server.metrics.loginCount, 2);
+    assert.strictEqual(server.metrics.requestCount, 2);
+
+    device.closeConnection();
+    await server.stop();
+  });
+
+  it('supports SMART requests over AES transport', async function () {
+    const server = createAesTestServer({
+      requestHandler(request) {
+        if (request && request.method === 'get_device_info') {
+          return { error_code: 0, result: { model: 'KS240', via: 'aes' } };
+        }
+        return { error_code: 0, result: {} };
+      },
+    });
+    const port = await server.start();
+    const client = new Client({
+      credentials: { username: 'user@example.com', password: 'secret' },
+    });
+    const device = createAesPlug(client, '127.0.0.1', port);
+
+    const response = await device.sendSmartCommand(
+      'get_device_info',
+      undefined,
+      undefined,
+      { transport: 'aes' },
+    );
+
+    assert.deepStrictEqual(response, { model: 'KS240', via: 'aes' });
+
+    device.closeConnection();
+    await server.stop();
+  });
+
+  it('supports AES credentialsHash login params without plaintext credentials', async function () {
+    const username = 'user@example.com';
+    const password = 'secret';
+    const server = createAesTestServer({
+      username,
+      password,
+      loginVariant: 'v2',
+    });
+    const port = await server.start();
+
+    const credentialsHash = Buffer.from(
+      JSON.stringify(expectedLoginParams(username, password, 'v2')),
+      'utf8',
+    ).toString('base64');
+    const client = new Client({
+      credentialsHash,
+      defaultSendOptions: { timeout: 1500, transport: 'aes' },
+    });
+    const device = createAesPlug(client, '127.0.0.1', port);
+
+    const response = await device.send('{"method":"one"}');
+    assert.deepStrictEqual(JSON.parse(response), {
+      error_code: 0,
+      result: { ok: true },
+    });
+    assert.strictEqual(server.metrics.handshakeCount, 1);
+    assert.strictEqual(server.metrics.loginCount, 1);
+
+    device.closeConnection();
+    await server.stop();
+  });
+
+  it('fails predictably when AES credentials are invalid', async function () {
+    const server = createAesTestServer({
+      username: 'correct@example.com',
+      password: 'correct-secret',
+    });
+    const port = await server.start();
+    const client = new Client({
+      credentials: { username: 'wrong@example.com', password: 'wrong-secret' },
+      defaultSendOptions: { timeout: 1500, transport: 'aes' },
+    });
+    const device = createAesPlug(client, '127.0.0.1', port);
+
+    await assert.rejects(
+      async () => {
+        await device.send('{"method":"one"}');
+      },
+      (error) => {
+        assert.match(error.message, /login failed with error_code -1501/i);
+        return true;
+      },
+    );
+    assert.ok(server.metrics.handshakeCount >= 1);
+    assert.ok(server.metrics.loginCount >= 4);
+
+    device.closeConnection();
+    await server.stop();
+  });
+});


### PR DESCRIPTION
Summary
- add new AES transport for authenticated /app devices using handshake + securePassthrough
- implement login_device credential flow with candidate fallback (credentials, credentialsHash, default TAPO)
- wire transport: 'aes' through Client and Device send option paths
- enable SMART calls over AES via existing client.sendSmart / device.sendSmart* APIs
- add AES transport integration tests and README transport updates

Validation
- npm run build
- npx eslint src/network/aes-connection.ts test/network/aes-connection.js src/client.ts src/device/index.ts
- npm run test:only -- test/network/aes-connection.js
- npm run test:only -- test/network/klap-connection.js