### PR TITLE
feat(transport): infer klap/aes defaults from mgt_encrypt_schm

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Many other TP-Link Plug and Bulb models may work as well. Note that Tapo devices
 - Child-scoped operations (`childId`) are supported for plug modules such as `away`, `schedule`, `timer`, `emeter`, and `dimmer`.
 - For child channels that expose brightness in child sysinfo (for example dimmer + fan combinations), dimmer capability is detected from child data when a `childId` is selected.
 - This project primarily targets the legacy TP-Link Smart Home protocol (`IOT.*` on port `9999`), and now includes experimental authenticated HTTP transports: `klap` and `aes` (credential or `credentialsHash` based).
+- If `sysInfo` includes encryption metadata (`mgt_encrypt_schm.encrypt_type` and optional `http_port`), device defaults are inferred automatically (`klap`/`aes` transport and port) unless you explicitly override them.
 - For SMART requests over authenticated transports, use `client.sendSmart(...)`, `device.sendSmartCommand(...)`, and `device.sendSmartRequests(...)` (including child-scoped `control_child` wrapping).
 - As a result, model names like `KS240` are still not automatically equivalent to full high-level feature support in this library.
 

--- a/test/client.js
+++ b/test/client.js
@@ -99,6 +99,74 @@ describe('Client', function () {
       expect(plugOverride.credentialsHash).to.equal('device-hash');
     });
 
+    it('should infer aes default transport and port from mgt_encrypt_schm', function () {
+      const client = new Client({
+        defaultSendOptions: { transport: 'tcp' },
+      });
+      const sysInfo = {
+        ...validPlugDiscoveryResponse.system.get_sysinfo,
+        mgt_encrypt_schm: {
+          encrypt_type: 'AES',
+          http_port: 8081,
+          lv: 2,
+        },
+      };
+
+      const plug = client.getPlug({
+        host: '127.0.0.1',
+        sysInfo,
+      });
+      expect(plug.defaultSendOptions.transport).to.equal('aes');
+      expect(plug.port).to.equal(8081);
+      plug.closeConnection();
+    });
+
+    it('should infer klap default transport from mgt_encrypt_schm', function () {
+      const client = new Client({
+        defaultSendOptions: { transport: 'tcp' },
+      });
+      const sysInfo = {
+        ...validPlugDiscoveryResponse.system.get_sysinfo,
+        mgt_encrypt_schm: {
+          encrypt_type: 'KLAP',
+          http_port: 80,
+          lv: 2,
+        },
+      };
+
+      const plug = client.getPlug({
+        host: '127.0.0.1',
+        sysInfo,
+      });
+      expect(plug.defaultSendOptions.transport).to.equal('klap');
+      expect(plug.port).to.equal(80);
+      plug.closeConnection();
+    });
+
+    it('should not override explicit transport and port with inferred values', function () {
+      const client = new Client({
+        defaultSendOptions: { transport: 'tcp' },
+      });
+      const sysInfo = {
+        ...validPlugDiscoveryResponse.system.get_sysinfo,
+        mgt_encrypt_schm: {
+          encrypt_type: 'AES',
+          http_port: 8081,
+          lv: 2,
+        },
+      };
+
+      const plug = client.getPlug({
+        host: '127.0.0.1',
+        port: 9999,
+        defaultSendOptions: { transport: 'tcp' },
+        sysInfo,
+      });
+      expect(plug.defaultSendOptions.transport).to.equal('tcp');
+      expect(plug.port).to.equal(9999);
+      plug.closeConnection();
+    });
+
     it('should redact credentials in getDevice debug logging', async function () {
       const debugSpy = sinon.spy();
       const logger = {


### PR DESCRIPTION
## Summary
- infer authenticated transport (`klap`/`aes`) from `sysInfo.mgt_encrypt_schm.encrypt_type`
- infer device port from `sysInfo.mgt_encrypt_schm.http_port`
- apply inferred defaults in `getPlug`, `getBulb`, and generic `getDeviceFromSysInfo` paths
- preserve explicit `defaultSendOptions.transport` and explicit `port` overrides
- make SMART defaults use authenticated transport defaults where available
- add constructor and network tests for inference/default behavior
- document inference behavior in README

## Validation
- npm run build
- npm run test:only -- test/network/aes-connection.js
- npm run test:only -- test/network/klap-connection.js
- npx mocha --color test/client.js --grep "constructor" --exit

Closes #9
