### PR TITLE
fix(client): let getSysInfo use transport-aware default port

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -459,7 +459,7 @@ class Client extends EventEmitter {
    */
   async getSysInfo(
     host: string,
-    port = 9999,
+    port?: number,
     sendOptions?: SendOptions,
   ): Promise<Sysinfo> {
     this.log.debug('client.getSysInfo(%j)', { host, port, sendOptions });

--- a/test/client.js
+++ b/test/client.js
@@ -143,6 +143,47 @@ describe('Client', function () {
       plug.closeConnection();
     });
 
+    it('should default getSysInfo port to 80 when client transport is authenticated', async function () {
+      const client = new Client({
+        defaultSendOptions: { transport: 'aes' },
+      });
+      const connection = {
+        send: sinon.stub().resolves(JSON.stringify(validPlugDiscoveryResponse)),
+        close: sinon.stub(),
+      };
+      const createConnectionStub = sinon
+        .stub(client, 'createConnection')
+        .returns(connection);
+
+      const sysInfo = await client.getSysInfo('127.0.0.1');
+      expect(sysInfo).to.deep.equal(validPlugDiscoveryResponse.system.get_sysinfo);
+      expect(createConnectionStub).to.have.been.calledOnce;
+      expect(createConnectionStub.firstCall.args[2]).to.equal(80);
+      expect(connection.send).to.have.been.calledOnce;
+      expect(connection.send.firstCall.args[1]).to.equal(80);
+    });
+
+    it('should default getDevice host lookup to 80 when client transport is authenticated', async function () {
+      const client = new Client({
+        defaultSendOptions: { transport: 'klap' },
+      });
+      const connection = {
+        send: sinon.stub().resolves(JSON.stringify(validPlugDiscoveryResponse)),
+        close: sinon.stub(),
+      };
+      const createConnectionStub = sinon
+        .stub(client, 'createConnection')
+        .returns(connection);
+
+      const device = await client.getDevice({
+        host: '127.0.0.1',
+      });
+
+      expect(createConnectionStub.firstCall.args[2]).to.equal(80);
+      expect(device.port).to.equal(80);
+      device.closeConnection();
+    });
+
     it('should not override explicit transport and port with inferred values', function () {
       const client = new Client({
         defaultSendOptions: { transport: 'tcp' },


### PR DESCRIPTION
## Summary
- remove hardcoded `9999` default from `Client.getSysInfo(host, port, sendOptions)`
- allow `client.send(...)` to apply transport-aware default port selection when `port` is omitted
- this fixes host-only `getDevice({ host })` / `getSysInfo(host)` for authenticated defaults (`klap`/`aes`) so they resolve to port `80`
- add constructor tests covering authenticated default-port behavior in both `getSysInfo` and `getDevice` host lookup paths

## Validation
- npm run build
- npx mocha --color test/client.js --grep "constructor" --exit

Closes #11
