### PR TITLE
feat: add KS200M PIR and ambient light support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ TP-Link Smarthome API
 
 | Model                                                                                                    | Type               |
 | -------------------------------------------------------------------------------------------------------- | ------------------ |
-| HS100, HS103, HS105, HS107, HS110,<br/>HS200, HS210, HS220, HS300, KP303, KP400<br/>ES20M, EP40, ...etc. | Plug               |
+| HS100, HS103, HS105, HS107, HS110,<br/>HS200, HS210, HS220, HS300, KP303, KP400<br/>ES20M, EP40, KS200M, ...etc. | Plug               |
 | KS240, KS225, S500D<br/>...etc.                                                                          | Plug (SMART, experimental) |
 | LB100, LB110, LB120, LB130, LB200, LB230, KL50, KL120, KL125<br/>...etc.                                 | Bulb               |
 | KL430<br/>...etc.                                                                                        | Bulb (light strip) |
@@ -26,6 +26,7 @@ Many other TP-Link Plug and Bulb models may work as well. Note that Tapo devices
 - Child-scoped operations (`childId`) are supported for plug modules such as `away`, `schedule`, `timer`, `emeter`, and `dimmer`.
 - For child channels that expose brightness in child sysinfo (for example dimmer + fan combinations), dimmer capability is detected from child data when a `childId` is selected.
 - This project primarily targets the legacy TP-Link Smart Home protocol (`IOT.*` on port `9999`), and now includes experimental authenticated HTTP transports: `klap` and `aes` (credential or `credentialsHash` based).
+- Legacy PIR wall switches such as `KS200M` now expose `plug.motion` (`smartlife.iot.PIR`) and `plug.ambientLight` (`smartlife.iot.LAS`) for local motion-sensor and ambient-light control.
 - If `sysInfo` includes encryption metadata (`mgt_encrypt_schm.encrypt_type` and optional `http_port`), device defaults are inferred automatically (`klap`/`aes` transport and port) unless you explicitly override them.
 - For SMART requests over authenticated transports, use `client.sendSmart(...)`, `device.sendSmartCommand(...)`, and `device.sendSmartRequests(...)` (including child-scoped `control_child` wrapping).
 - Initial SMART switch support includes SMART power/LED paths and high-level helpers for `fan`, `lightPreset`, `lightTransition`, and `overheatProtection` (including child-scoped KS240 channels).

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,12 @@ export {
 } from './plug';
 export type { default as Away, AwayRule, AwayRuleInput } from './plug/away';
 export type {
+  default as AmbientLight,
+  AmbientLightConfigResponse,
+  AmbientLightDeviceConfig,
+  AmbientLightPreset,
+} from './plug/ambient-light';
+export type {
   default as Dimmer,
   DimmerActionInput,
   DimmerTransitionInput,
@@ -67,6 +73,13 @@ export type {
   default as LightTransition,
   LightTransitionInfo,
 } from './plug/light-transition';
+export type {
+  default as Motion,
+  MotionAdcValueResponse,
+  MotionConfigResponse,
+  MotionRangeName,
+  MotionState,
+} from './plug/motion';
 export type { default as OverheatProtection } from './plug/overheat-protection';
 export type {
   default as PlugSchedule,

--- a/src/plug/ambient-light.ts
+++ b/src/plug/ambient-light.ts
@@ -1,0 +1,187 @@
+import type { SendOptions } from '../client';
+import type Plug from './index';
+
+export type AmbientLightPreset = {
+  adc: number;
+  name: string;
+  value: number;
+};
+
+export type AmbientLightDeviceConfig = {
+  dark_index?: number;
+  enable?: boolean | number;
+  hw_id?: number;
+  level_array?: AmbientLightPreset[];
+  max_adc?: number;
+  min_adc?: number;
+};
+
+export type AmbientLightConfigResponse = {
+  devs: AmbientLightDeviceConfig[];
+  err_code: number;
+  ver?: string;
+};
+
+/**
+ * Legacy ambient light (LAS) module found on PIR wall switches such as KS200M.
+ */
+export default class AmbientLight {
+  #config?: AmbientLightDeviceConfig;
+
+  #brightness?: number;
+
+  constructor(
+    readonly device: Plug,
+    readonly apiModuleName: string,
+    readonly childId: string | undefined = undefined,
+  ) {}
+
+  private assertLegacyOnlyMethod(
+    methodName: string,
+    sendOptions?: SendOptions,
+  ): void {
+    if (this.device.shouldUseSmartMethods(sendOptions)) {
+      throw new Error(`${methodName} is not supported for SMART switches.`);
+    }
+  }
+
+  private applyConfig(response: AmbientLightConfigResponse): void {
+    if (Array.isArray(response.devs) && response.devs.length > 0) {
+      [this.#config] = response.devs;
+    }
+  }
+
+  get config(): AmbientLightDeviceConfig | undefined {
+    return this.#config;
+  }
+
+  get presets(): AmbientLightPreset[] | undefined {
+    return this.#config?.level_array;
+  }
+
+  get enabled(): boolean | undefined {
+    if (this.#config?.enable === undefined) {
+      return undefined;
+    }
+    return Boolean(this.#config.enable);
+  }
+
+  get brightness(): number | undefined {
+    return this.#brightness;
+  }
+
+  async getConfig(
+    sendOptions?: SendOptions,
+  ): Promise<AmbientLightConfigResponse> {
+    this.assertLegacyOnlyMethod('AmbientLight#getConfig', sendOptions);
+    const response = (await this.device.sendCommand(
+      {
+        [this.apiModuleName]: {
+          get_config: {},
+        },
+      },
+      this.childId,
+      sendOptions,
+    )) as AmbientLightConfigResponse;
+    this.applyConfig(response);
+    return response;
+  }
+
+  async getCurrentBrightness(sendOptions?: SendOptions): Promise<number> {
+    this.assertLegacyOnlyMethod(
+      'AmbientLight#getCurrentBrightness',
+      sendOptions,
+    );
+    const response = (await this.device.sendCommand(
+      {
+        [this.apiModuleName]: {
+          get_current_brt: {},
+        },
+      },
+      this.childId,
+      sendOptions,
+    )) as { err_code: number; value?: number };
+    this.#brightness =
+      typeof response.value === 'number' ? response.value : undefined;
+    return this.#brightness ?? 0;
+  }
+
+  async getInfo(
+    sendOptions?: SendOptions,
+  ): Promise<{
+    config: AmbientLightDeviceConfig | undefined;
+    brightness: number | undefined;
+  }> {
+    this.assertLegacyOnlyMethod('AmbientLight#getInfo', sendOptions);
+    const response = (await this.device.sendCommand(
+      {
+        [this.apiModuleName]: {
+          get_config: {},
+          get_current_brt: {},
+        },
+      },
+      this.childId,
+      sendOptions,
+    )) as {
+      [key: string]: {
+        get_config?: AmbientLightConfigResponse;
+        get_current_brt?: { err_code: number; value?: number };
+      };
+    };
+
+    const las = response[this.apiModuleName];
+    if (las?.get_config) {
+      this.applyConfig(las.get_config);
+    }
+    if (typeof las?.get_current_brt?.value === 'number') {
+      this.#brightness = las.get_current_brt.value;
+    }
+
+    return {
+      config: this.#config,
+      brightness: this.#brightness,
+    };
+  }
+
+  async setEnabled(
+    value: boolean,
+    sendOptions?: SendOptions,
+  ): Promise<unknown> {
+    this.assertLegacyOnlyMethod('AmbientLight#setEnabled', sendOptions);
+    const response = await this.device.sendCommand(
+      {
+        [this.apiModuleName]: {
+          set_enable: { enable: value ? 1 : 0 },
+        },
+      },
+      this.childId,
+      sendOptions,
+    );
+    if (this.#config) {
+      this.#config = { ...this.#config, enable: value ? 1 : 0 };
+    }
+    return response;
+  }
+
+  async setBrightnessLimit(
+    value: number,
+    sendOptions?: SendOptions,
+  ): Promise<unknown> {
+    this.assertLegacyOnlyMethod(
+      'AmbientLight#setBrightnessLimit',
+      sendOptions,
+    );
+    return this.device.sendCommand(
+      {
+        [this.apiModuleName]: {
+          set_brt_level: {
+            index: 0,
+            value,
+          },
+        },
+      },
+      this.childId,
+      sendOptions,
+    );
+  }
+}

--- a/src/plug/index.ts
+++ b/src/plug/index.ts
@@ -17,11 +17,13 @@ import {
   isObjectLike,
   type HasErrCode,
 } from '../utils';
+import AmbientLight from './ambient-light';
 import Away from './away';
 import Dimmer from './dimmer';
 import Fan from './fan';
 import LightPreset from './light-preset';
 import LightTransition from './light-transition';
+import Motion from './motion';
 import OverheatProtection from './overheat-protection';
 import Schedule from './schedule';
 import SmartLed from './smart-led';
@@ -207,6 +209,8 @@ class Plug extends Device {
 
   away: Away;
 
+  ambientLight: AmbientLight;
+
   cloud: Cloud;
 
   dimmer: Dimmer;
@@ -216,6 +220,8 @@ class Plug extends Device {
   lightPreset: LightPreset;
 
   lightTransition: LightTransition;
+
+  motion: Motion;
 
   overheatProtection: OverheatProtection;
 
@@ -261,6 +267,15 @@ class Plug extends Device {
     this.away = new Away(this, 'anti_theft', childId);
 
     /**
+     * @borrows AmbientLight#getConfig as Plug.ambientLight#getConfig
+     * @borrows AmbientLight#getCurrentBrightness as Plug.ambientLight#getCurrentBrightness
+     * @borrows AmbientLight#getInfo as Plug.ambientLight#getInfo
+     * @borrows AmbientLight#setEnabled as Plug.ambientLight#setEnabled
+     * @borrows AmbientLight#setBrightnessLimit as Plug.ambientLight#setBrightnessLimit
+     */
+    this.ambientLight = new AmbientLight(this, 'smartlife.iot.LAS', childId);
+
+    /**
      * @borrows Cloud#getInfo as Plug.cloud#getInfo
      * @borrows Cloud#bind as Plug.cloud#bind
      * @borrows Cloud#unbind as Plug.cloud#unbind
@@ -289,6 +304,17 @@ class Plug extends Device {
     this.lightPreset = new LightPreset(this, childId);
 
     this.lightTransition = new LightTransition(this, childId);
+
+    /**
+     * @borrows Motion#getConfig as Plug.motion#getConfig
+     * @borrows Motion#getAdcValue as Plug.motion#getAdcValue
+     * @borrows Motion#getInfo as Plug.motion#getInfo
+     * @borrows Motion#setEnabled as Plug.motion#setEnabled
+     * @borrows Motion#setRange as Plug.motion#setRange
+     * @borrows Motion#setThreshold as Plug.motion#setThreshold
+     * @borrows Motion#setInactivityTimeout as Plug.motion#setInactivityTimeout
+     */
+    this.motion = new Motion(this, 'smartlife.iot.PIR', childId);
 
     this.overheatProtection = new OverheatProtection(this, childId);
 
@@ -842,6 +868,23 @@ class Plug extends Device {
       );
     }
     return this.getBrightnessValue() !== undefined;
+  }
+
+  /**
+   * True if this legacy wall switch exposes a PIR motion sensor namespace.
+   */
+  get supportsMotionSensor(): boolean {
+    return (
+      !this.isSmartProtocolSwitch() &&
+      (/PIR/i.test(this.description ?? '') || /^KS200M/i.test(this.model))
+    );
+  }
+
+  /**
+   * True if this legacy wall switch exposes LAS ambient light controls.
+   */
+  get supportsAmbientLight(): boolean {
+    return this.supportsMotionSensor;
   }
 
   /**

--- a/src/plug/motion.ts
+++ b/src/plug/motion.ts
@@ -1,0 +1,293 @@
+import type { SendOptions } from '../client';
+import type Plug from './index';
+
+const MOTION_RANGE_NAMES = ['Far', 'Mid', 'Near', 'Custom'] as const;
+
+export type MotionRangeName = (typeof MOTION_RANGE_NAMES)[number];
+
+export type MotionConfigResponse = {
+  array: number[];
+  cold_time: number;
+  enable: boolean | number;
+  err_code: number;
+  max_adc: number;
+  min_adc: number;
+  trigger_index: number;
+  version?: string;
+};
+
+export type MotionAdcValueResponse = {
+  err_code: number;
+  value: number;
+};
+
+export type MotionState = {
+  adcMax: number;
+  adcMid: number;
+  adcMin: number;
+  adcValue: number;
+  enabled: boolean;
+  inactivityTimeout: number;
+  pirPercent: number;
+  pirTriggered: boolean;
+  pirValue: number;
+  rangeIndex: number;
+  rangeName?: MotionRangeName;
+  threshold: number;
+};
+
+/**
+ * Legacy PIR motion module found on wall switches such as KS200M.
+ */
+export default class Motion {
+  #config?: MotionConfigResponse;
+
+  #adcValue?: number;
+
+  constructor(
+    readonly device: Plug,
+    readonly apiModuleName: string,
+    readonly childId: string | undefined = undefined,
+  ) {}
+
+  private assertLegacyOnlyMethod(
+    methodName: string,
+    sendOptions?: SendOptions,
+  ): void {
+    if (this.device.shouldUseSmartMethods(sendOptions)) {
+      throw new Error(`${methodName} is not supported for SMART switches.`);
+    }
+  }
+
+  private static normalizeRange(range: MotionRangeName | number): number {
+    if (typeof range === 'number') {
+      return Math.max(0, Math.floor(range));
+    }
+
+    const normalized = range.trim().toLowerCase();
+    const foundIndex = MOTION_RANGE_NAMES.findIndex(
+      (candidate) => candidate.toLowerCase() === normalized,
+    );
+    if (foundIndex === -1) {
+      throw new Error(
+        `Invalid motion range "${range}". Expected one of ${MOTION_RANGE_NAMES.join(', ')}`,
+      );
+    }
+    return foundIndex;
+  }
+
+  private getRangeThreshold(index: number): number | undefined {
+    const array = this.#config?.array;
+    if (!Array.isArray(array)) {
+      return undefined;
+    }
+    return array[index];
+  }
+
+  private getAdcMid(): number | undefined {
+    const config = this.#config;
+    if (
+      config == null ||
+      typeof config.min_adc !== 'number' ||
+      typeof config.max_adc !== 'number'
+    ) {
+      return undefined;
+    }
+    return Math.floor(Math.abs(config.max_adc - config.min_adc) / 2);
+  }
+
+  private getStateFromCache(): MotionState | undefined {
+    if (this.#config == null || this.#adcValue === undefined) {
+      return undefined;
+    }
+
+    const adcMid = this.getAdcMid();
+    if (adcMid === undefined) {
+      return undefined;
+    }
+
+    const rangeIndex = this.#config.trigger_index;
+    const threshold = this.getRangeThreshold(rangeIndex) ?? 0;
+    const pirValue = adcMid - this.#adcValue;
+    const divisor =
+      pirValue < 0
+        ? adcMid - this.#config.min_adc
+        : this.#config.max_adc - adcMid;
+    const pirPercent = divisor === 0 ? 0 : (pirValue / divisor) * 100;
+    const enabled = Boolean(this.#config.enable);
+
+    return {
+      adcMax: this.#config.max_adc,
+      adcMid,
+      adcMin: this.#config.min_adc,
+      adcValue: this.#adcValue,
+      enabled,
+      inactivityTimeout: this.#config.cold_time,
+      pirPercent,
+      pirTriggered: enabled && Math.abs(pirPercent) > 100 - threshold,
+      pirValue,
+      rangeIndex,
+      rangeName: MOTION_RANGE_NAMES[rangeIndex],
+      threshold,
+    };
+  }
+
+  get config(): MotionConfigResponse | undefined {
+    return this.#config;
+  }
+
+  get state(): MotionState | undefined {
+    return this.getStateFromCache();
+  }
+
+  async getConfig(sendOptions?: SendOptions): Promise<MotionConfigResponse> {
+    this.assertLegacyOnlyMethod('Motion#getConfig', sendOptions);
+    const response = (await this.device.sendCommand(
+      {
+        [this.apiModuleName]: {
+          get_config: {},
+        },
+      },
+      this.childId,
+      sendOptions,
+    )) as MotionConfigResponse;
+    this.#config = response;
+    return response;
+  }
+
+  async getAdcValue(sendOptions?: SendOptions): Promise<number> {
+    this.assertLegacyOnlyMethod('Motion#getAdcValue', sendOptions);
+    const response = (await this.device.sendCommand(
+      {
+        [this.apiModuleName]: {
+          get_adc_value: {},
+        },
+      },
+      this.childId,
+      sendOptions,
+    )) as MotionAdcValueResponse;
+    this.#adcValue =
+      typeof response.value === 'number' ? response.value : undefined;
+    return this.#adcValue ?? 0;
+  }
+
+  async getInfo(sendOptions?: SendOptions): Promise<MotionState | undefined> {
+    this.assertLegacyOnlyMethod('Motion#getInfo', sendOptions);
+    const response = (await this.device.sendCommand(
+      {
+        [this.apiModuleName]: {
+          get_config: {},
+          get_adc_value: {},
+        },
+      },
+      this.childId,
+      sendOptions,
+    )) as {
+      [key: string]: {
+        get_config?: MotionConfigResponse;
+        get_adc_value?: MotionAdcValueResponse;
+      };
+    };
+
+    const pir = response[this.apiModuleName];
+    if (pir?.get_config) {
+      this.#config = pir.get_config;
+    }
+    if (typeof pir?.get_adc_value?.value === 'number') {
+      this.#adcValue = pir.get_adc_value.value;
+    }
+    return this.getStateFromCache();
+  }
+
+  async setEnabled(
+    value: boolean,
+    sendOptions?: SendOptions,
+  ): Promise<unknown> {
+    this.assertLegacyOnlyMethod('Motion#setEnabled', sendOptions);
+    const response = await this.device.sendCommand(
+      {
+        [this.apiModuleName]: {
+          set_enable: { enable: value ? 1 : 0 },
+        },
+      },
+      this.childId,
+      sendOptions,
+    );
+    if (this.#config) {
+      this.#config = { ...this.#config, enable: value ? 1 : 0 };
+    }
+    return response;
+  }
+
+  async setRange(
+    range: MotionRangeName | number,
+    sendOptions?: SendOptions,
+  ): Promise<unknown> {
+    this.assertLegacyOnlyMethod('Motion#setRange', sendOptions);
+    const index = Motion.normalizeRange(range);
+    const response = await this.device.sendCommand(
+      {
+        [this.apiModuleName]: {
+          set_trigger_sens: { index },
+        },
+      },
+      this.childId,
+      sendOptions,
+    );
+    if (this.#config) {
+      this.#config = { ...this.#config, trigger_index: index };
+    }
+    return response;
+  }
+
+  async setThreshold(
+    value: number,
+    sendOptions?: SendOptions,
+  ): Promise<unknown> {
+    this.assertLegacyOnlyMethod('Motion#setThreshold', sendOptions);
+    const response = await this.device.sendCommand(
+      {
+        [this.apiModuleName]: {
+          set_trigger_sens: {
+            index: 3,
+            value,
+          },
+        },
+      },
+      this.childId,
+      sendOptions,
+    );
+    if (this.#config) {
+      const nextArray = Array.isArray(this.#config.array)
+        ? [...this.#config.array]
+        : [];
+      nextArray[3] = value;
+      this.#config = {
+        ...this.#config,
+        array: nextArray,
+        trigger_index: 3,
+      };
+    }
+    return response;
+  }
+
+  async setInactivityTimeout(
+    timeout: number,
+    sendOptions?: SendOptions,
+  ): Promise<unknown> {
+    this.assertLegacyOnlyMethod('Motion#setInactivityTimeout', sendOptions);
+    const response = await this.device.sendCommand(
+      {
+        [this.apiModuleName]: {
+          set_cold_time: { cold_time: timeout },
+        },
+      },
+      this.childId,
+      sendOptions,
+    );
+    if (this.#config) {
+      this.#config = { ...this.#config, cold_time: timeout };
+    }
+    return response;
+  }
+}

--- a/test/fixtures/python-kasa-iot/KS200M(US)_1.0_1.0.12.min.json
+++ b/test/fixtures/python-kasa-iot/KS200M(US)_1.0_1.0.12.min.json
@@ -1,0 +1,104 @@
+{
+  "smartlife.iot.LAS": {
+    "get_config": {
+      "devs": [
+        {
+          "dark_index": 0,
+          "enable": 1,
+          "hw_id": 0,
+          "level_array": [
+            {
+              "adc": 390,
+              "name": "cloudy",
+              "value": 15
+            },
+            {
+              "adc": 300,
+              "name": "overcast",
+              "value": 11
+            },
+            {
+              "adc": 222,
+              "name": "dawn",
+              "value": 8
+            },
+            {
+              "adc": 222,
+              "name": "twilight",
+              "value": 8
+            },
+            {
+              "adc": 111,
+              "name": "total darkness",
+              "value": 4
+            },
+            {
+              "adc": 2400,
+              "name": "custom",
+              "value": 94
+            }
+          ],
+          "max_adc": 2550,
+          "min_adc": 0
+        }
+      ],
+      "err_code": 0,
+      "ver": "1.0"
+    },
+    "get_current_brt": {
+      "err_code": 0,
+      "value": 8
+    }
+  },
+  "smartlife.iot.PIR": {
+    "get_config": {
+      "array": [
+        80,
+        50,
+        20,
+        0
+      ],
+      "cold_time": 600000,
+      "enable": 1,
+      "err_code": 0,
+      "max_adc": 4095,
+      "min_adc": 0,
+      "trigger_index": 1,
+      "version": "1.0"
+    },
+    "get_adc_value": {
+      "err_code": 0,
+      "value": 512
+    }
+  },
+  "system": {
+    "get_sysinfo": {
+      "active_mode": "none",
+      "alias": "KS200M Fixture",
+      "dev_name": "Smart Light Switch with PIR",
+      "deviceId": "0000000000000000000000000000000000000000",
+      "err_code": 0,
+      "feature": "TIM",
+      "hwId": "00000000000000000000000000000000",
+      "hw_ver": "1.0",
+      "icon_hash": "",
+      "latitude_i": 0,
+      "led_off": 0,
+      "longitude_i": 0,
+      "mac": "98:25:4A:00:00:00",
+      "mic_type": "IOT.SMARTPLUGSWITCH",
+      "model": "KS200M(US)",
+      "next_action": {
+        "type": -1
+      },
+      "obd_src": "tplink",
+      "oemId": "00000000000000000000000000000000",
+      "on_time": 0,
+      "relay_state": 0,
+      "rssi": -55,
+      "status": "new",
+      "sw_ver": "1.0.12 Build 240507 Rel.143458",
+      "updating": 0
+    }
+  }
+}

--- a/test/python-kasa-fixture-baseline.js
+++ b/test/python-kasa-fixture-baseline.js
@@ -17,6 +17,16 @@ function loadFixture(fileName) {
   return JSON.parse(fs.readFileSync(fixturePath, 'utf8'));
 }
 
+function loadIotFixture(fileName) {
+  const fixturePath = path.join(
+    __dirname,
+    'fixtures',
+    'python-kasa-iot',
+    fileName,
+  );
+  return JSON.parse(fs.readFileSync(fixturePath, 'utf8'));
+}
+
 function toLegacyPlugSysInfo(fixture) {
   const discovery = fixture.discovery_result.result;
   const info = fixture.get_device_info;
@@ -50,6 +60,130 @@ function toLegacyPlugSysInfo(fixture) {
 }
 
 describe('python-kasa fixture baseline', function () {
+  it('wires KS200M as a legacy local plug with PIR/LAS support', function () {
+    const fixture = loadIotFixture('KS200M(US)_1.0_1.0.12.min.json');
+    const sysInfo = fixture.system.get_sysinfo;
+    const client = new Client({
+      defaultSendOptions: { transport: 'tcp' },
+    });
+
+    const device = client.getPlug({ host: '127.0.0.1', sysInfo });
+    expect(device.port).to.equal(9999);
+    expect(device.supportsDimmer).to.equal(false);
+    expect(device.supportsMotionSensor).to.equal(true);
+    expect(device.supportsAmbientLight).to.equal(true);
+    device.closeConnection();
+  });
+
+  it('maps KS200M PIR calls to the legacy smartlife.iot.PIR namespace', async function () {
+    const fixture = loadIotFixture('KS200M(US)_1.0_1.0.12.min.json');
+    const sysInfo = fixture.system.get_sysinfo;
+    const client = new Client();
+    const device = client.getPlug({ host: '127.0.0.1', sysInfo });
+
+    const sendCommandStub = sinon
+      .stub(device, 'sendCommand')
+      .callsFake(async (command) => {
+        const pir = command['smartlife.iot.PIR'];
+        if (pir && pir.get_config && pir.get_adc_value) {
+          return { 'smartlife.iot.PIR': fixture['smartlife.iot.PIR'] };
+        }
+        if (pir && (pir.set_trigger_sens || pir.set_cold_time || pir.set_enable)) {
+          return { err_code: 0 };
+        }
+        throw new Error(`Unexpected command: ${JSON.stringify(command)}`);
+      });
+
+    const state = await device.motion.getInfo();
+    expect(state).to.containSubset({
+      enabled: true,
+      rangeIndex: 1,
+      rangeName: 'Mid',
+      threshold: 50,
+      adcValue: 512,
+      inactivityTimeout: 600000,
+    });
+
+    await device.motion.setThreshold(42);
+    await device.motion.setInactivityTimeout(120000);
+    await device.motion.setEnabled(false);
+
+    expect(sendCommandStub.firstCall.args[0]).to.containSubset({
+      'smartlife.iot.PIR': {
+        get_config: {},
+        get_adc_value: {},
+      },
+    });
+    expect(sendCommandStub.secondCall.args[0]).to.containSubset({
+      'smartlife.iot.PIR': {
+        set_trigger_sens: { index: 3, value: 42 },
+      },
+    });
+    expect(sendCommandStub.thirdCall.args[0]).to.containSubset({
+      'smartlife.iot.PIR': {
+        set_cold_time: { cold_time: 120000 },
+      },
+    });
+    expect(sendCommandStub.getCall(3).args[0]).to.containSubset({
+      'smartlife.iot.PIR': {
+        set_enable: { enable: 0 },
+      },
+    });
+
+    device.closeConnection();
+  });
+
+  it('maps KS200M LAS calls to the legacy smartlife.iot.LAS namespace', async function () {
+    const fixture = loadIotFixture('KS200M(US)_1.0_1.0.12.min.json');
+    const sysInfo = fixture.system.get_sysinfo;
+    const client = new Client();
+    const device = client.getPlug({ host: '127.0.0.1', sysInfo });
+
+    const sendCommandStub = sinon
+      .stub(device, 'sendCommand')
+      .callsFake(async (command) => {
+        const las = command['smartlife.iot.LAS'];
+        if (las && las.get_config && las.get_current_brt) {
+          return { 'smartlife.iot.LAS': fixture['smartlife.iot.LAS'] };
+        }
+        if (las && (las.set_brt_level || las.set_enable)) {
+          return { err_code: 0 };
+        }
+        throw new Error(`Unexpected command: ${JSON.stringify(command)}`);
+      });
+
+    const info = await device.ambientLight.getInfo();
+    expect(info).to.containSubset({
+      brightness: 8,
+      config: {
+        enable: 1,
+      },
+    });
+    expect(device.ambientLight.presets).to.be.an('array').with.length.greaterThan(0);
+
+    await device.ambientLight.setBrightnessLimit(15);
+    await device.ambientLight.setEnabled(false);
+
+    expect(sendCommandStub.firstCall.args[0]).to.containSubset({
+      'smartlife.iot.LAS': {
+        get_config: {},
+        get_current_brt: {},
+      },
+    });
+    expect(sendCommandStub.secondCall.args[0]).to.containSubset({
+      'smartlife.iot.LAS': {
+        set_brt_level: { index: 0, value: 15 },
+      },
+    });
+    expect(sendCommandStub.thirdCall.args[0]).to.containSubset({
+      'smartlife.iot.LAS': {
+        set_enable: { enable: 0 },
+      },
+    });
+
+    device.closeConnection();
+  });
+
   it('infers AES transport defaults from KS240 fixture discovery metadata', function () {
     const fixture = loadFixture('KS240(US)_1.0_1.0.5.min.json');
     const sysInfo = toLegacyPlugSysInfo(fixture);
@@ -225,7 +359,10 @@ describe('python-kasa fixture baseline', function () {
       if (request.method !== 'control_child') {
         return JSON.stringify({ error_code: 0, result: {} });
       }
-      const method = request.params?.requestData?.method;
+      const method =
+        request.params &&
+        request.params.requestData &&
+        request.params.requestData.method;
       if (method === 'get_auto_off_config') {
         return JSON.stringify({
           error_code: 0,


### PR DESCRIPTION
Adds legacy KS200M wall-switch support via `plug.motion` (`smartlife.iot.PIR`) and `plug.ambientLight` (`smartlife.iot.LAS`), wires the modules into `Plug`, exports their types, documents the capability, and adds python-kasa fixture baseline coverage.

Validation:
- `npm run build`
- `npx mocha --color test/python-kasa-fixture-baseline.js --exit`
- `npx mocha --color test/client.js --grep "KS240-style child wiring|constructor" --exit`
- `npx eslint src/plug/ambient-light.ts src/plug/motion.ts test/python-kasa-fixture-baseline.js --rule "prettier/prettier: off" --format=pretty`

Note: repo-wide `npm run lint` is noisy on this Windows checkout because Prettier reports CRLF across many untouched files.
