### PR TITLE
Fix authenticated SMART bootstrap and discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [Unreleased]
+
+### Features
+
+* **Client:** add authenticated `get_device_info` bootstrap/normalization and SMART TDP v2 discovery on UDP ports 20002 and 20004 while preserving legacy discovery.
+
 ## [5.0.0](https://github.com/plasticrake/tplink-smarthome-api/compare/v4.2.0...v5.0.0) (2023-11-15)
 
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -22,6 +22,13 @@ import TcpConnection from './network/tcp-connection';
 import UdpConnection from './network/udp-connection';
 import Plug, { hasSysinfoChildren } from './plug';
 import type { Realtime } from './shared/emeter';
+import SmartError from './smart-error';
+import {
+  createSmartDiscoveryProbe,
+  normalizeSmartSysInfo,
+  parseSmartDiscoveryPacket,
+  SMART_DISCOVERY_PORTS,
+} from './smart-discovery';
 import { compareMac, isObjectLike } from './utils';
 
 const discoveryMsgBuf = encrypt('{"system":{"get_sysinfo":{}}}');
@@ -32,6 +39,7 @@ export type DeviceDiscovery = { status: string; seenOnDiscovery: number };
 export type AnyDeviceDiscovery = (Bulb | Plug) & Partial<DeviceDiscovery>;
 
 type SysinfoResponse = { system: { get_sysinfo: Sysinfo } };
+type SmartResponse = { error_code: number; result?: unknown };
 type EmeterResponse = PlugEmeterResponse | BulbEmeterResponse;
 type PlugEmeterResponse = {
   emeter?: { get_realtime?: { err_code: number } & Realtime };
@@ -71,6 +79,10 @@ function isSysinfoResponse(candidate: unknown): candidate is SysinfoResponse {
     isObjectLike(candidate.system) &&
     'get_sysinfo' in candidate.system
   );
+}
+
+function isSmartResponse(candidate: unknown): candidate is SmartResponse {
+  return isObjectLike(candidate) && typeof candidate.error_code === 'number';
 }
 
 function isAuthenticatedTransport(
@@ -286,6 +298,8 @@ class Client extends EventEmitter {
 
   discoveryTimer: NodeJS.Timeout | null = null;
 
+  discoveryTimeoutTimer: NodeJS.Timeout | null = null;
+
   discoveryPacketSequence = 0;
 
   maxSocketId = 0;
@@ -463,6 +477,12 @@ class Client extends EventEmitter {
     sendOptions?: SendOptions,
   ): Promise<Sysinfo> {
     this.log.debug('client.getSysInfo(%j)', { host, port, sendOptions });
+
+    const transport = sendOptions?.transport ?? this.defaultSendOptions.transport;
+    if (isAuthenticatedTransport(transport)) {
+      return this.getSmartSysInfo(host, port, sendOptions, transport);
+    }
+
     const response = await this.send(
       '{"system":{"get_sysinfo":{}}}',
       host,
@@ -476,6 +496,47 @@ class Client extends EventEmitter {
     }
 
     throw new Error(`Unexpected Response: ${response}`);
+  }
+
+  private async getSmartSysInfo(
+    host: string,
+    port: number | undefined,
+    sendOptions: SendOptions | undefined,
+    transport: AuthenticatedTransport,
+  ): Promise<Sysinfo> {
+    const request: SmartRequestPayload = { method: 'get_device_info' };
+    const response = await this.send(request, host, port, sendOptions);
+    let responseObj: unknown;
+    try {
+      responseObj = JSON.parse(response);
+    } catch {
+      throw new Error('Unexpected SMART get_device_info response');
+    }
+
+    if (!isSmartResponse(responseObj)) {
+      throw new Error('Unexpected SMART get_device_info response');
+    }
+    if (responseObj.error_code !== 0) {
+      throw new SmartError(
+        'SMART request failed',
+        responseObj.error_code,
+        request.method,
+        JSON.stringify({ error_code: responseObj.error_code }),
+        JSON.stringify(request),
+      );
+    }
+    if (!isObjectLike(responseObj.result)) {
+      throw new Error('Unexpected SMART get_device_info response');
+    }
+
+    const sysInfo = normalizeSmartSysInfo(responseObj.result, {
+      transport,
+      port: port ?? 80,
+    });
+    if (!isPlugSysinfo(sysInfo)) {
+      throw new Error('Unexpected SMART get_device_info result');
+    }
+    return sysInfo;
   }
 
   /**
@@ -727,9 +788,121 @@ class Client extends EventEmitter {
       const socket = createSocket('udp4');
       this.socket = socket;
 
-      socket.on('message', (msg, rinfo) => {
-        const decryptedMsg = decrypt(msg).toString('utf8');
+      const processDiscoveredSysInfo = (
+        sysInfo: Sysinfo,
+        rinfo: RemoteInfo,
+        useDiscoveryPort: boolean,
+      ): void => {
+        if (deviceTypes && deviceTypes.length > 0) {
+          const deviceType = this.getTypeFromSysInfo(sysInfo);
+          if (!(deviceTypes as string[]).includes(deviceType)) {
+            this.log.debug(
+              `client.startDiscovery(): Filtered out: ${sysInfo.alias} [${sysInfo.deviceId}] (${deviceType}), allowed device types: (%j)`,
+              deviceTypes,
+            );
+            return;
+          }
+        }
 
+        let mac: string;
+        if ('mac' in sysInfo) mac = sysInfo.mac;
+        else if ('mic_mac' in sysInfo) mac = sysInfo.mic_mac;
+        else if ('ethernet_mac' in sysInfo) mac = sysInfo.ethernet_mac;
+        else mac = '';
+
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        if (macAddresses && macAddresses.length > 0) {
+          if (!compareMac(mac, macAddresses)) {
+            this.log.debug(
+              `client.startDiscovery(): Filtered out: ${sysInfo.alias} [${sysInfo.deviceId}] (${mac}), allowed macs: (%j)`,
+              macAddresses,
+            );
+            return;
+          }
+        }
+
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        if (excludeMacAddresses && excludeMacAddresses.length > 0) {
+          if (compareMac(mac, excludeMacAddresses)) {
+            this.log.debug(
+              `client.startDiscovery(): Filtered out: ${sysInfo.alias} [${sysInfo.deviceId}] (${mac}), excluded mac`,
+            );
+            return;
+          }
+        }
+
+        if (typeof filterCallback === 'function' && !filterCallback(sysInfo)) {
+          this.log.debug(
+            `client.startDiscovery(): Filtered out: ${sysInfo.alias} [${sysInfo.deviceId}], callback`,
+          );
+          return;
+        }
+
+        this.createOrUpdateDeviceFromSysInfo({
+          sysInfo,
+          host: rinfo.address,
+          port: useDiscoveryPort ? rinfo.port : undefined,
+          breakoutChildren,
+          options: deviceOptions,
+        });
+      };
+
+      socket.on('message', (msg, rinfo) => {
+        if (
+          SMART_DISCOVERY_PORTS.some(
+            (smartDiscoveryPort) => smartDiscoveryPort === rinfo.port,
+          )
+        ) {
+          try {
+            const packet = parseSmartDiscoveryPacket(msg);
+            const response = packet.payload;
+            if (!isSmartResponse(response)) {
+              throw new Error('Unexpected SMART discovery response');
+            }
+            if (response.error_code !== 0) {
+              throw new SmartError(
+                'SMART discovery request failed',
+                response.error_code,
+                'discovery',
+                JSON.stringify({ error_code: response.error_code }),
+                'TDP v2 discovery probe',
+              );
+            }
+            if (!isObjectLike(response.result)) {
+              throw new Error('Unexpected SMART discovery result');
+            }
+
+            const sysInfo = normalizeSmartSysInfo(response.result);
+            if (!isPlugSysinfo(sysInfo)) {
+              throw new Error('Unexpected SMART discovery device info');
+            }
+
+            this.log.debug(
+              'client.startDiscovery(): received SMART TDP response from %s:%s',
+              rinfo.address,
+              rinfo.port,
+            );
+            // TDP responses originate from UDP/20002 or UDP/20004;
+            // mgt_encrypt_schm controls the TCP request port and must not be
+            // replaced by either discovery source port.
+            processDiscoveredSysInfo(sysInfo, rinfo, false);
+          } catch (err) {
+            this.log.debug(
+              'client.startDiscovery(): invalid SMART TDP response from %s:%s: %s',
+              rinfo.address,
+              rinfo.port,
+              err,
+            );
+            this.emit('discovery-invalid', {
+              rinfo,
+              response: msg,
+              decryptedResponse: msg,
+            });
+          }
+          return;
+        }
+
+        const decryptedMsg = decrypt(msg).toString('utf8');
         this.log.debug(
           `client.startDiscovery(): socket:message From: ${rinfo.address} ${rinfo.port} Message: ${decryptedMsg}`,
         );
@@ -761,60 +934,7 @@ class Client extends EventEmitter {
             return;
           }
 
-          if (deviceTypes && deviceTypes.length > 0) {
-            const deviceType = this.getTypeFromSysInfo(sysInfo);
-            if (!(deviceTypes as string[]).includes(deviceType)) {
-              this.log.debug(
-                `client.startDiscovery(): Filtered out: ${sysInfo.alias} [${sysInfo.deviceId}] (${deviceType}), allowed device types: (%j)`,
-                deviceTypes,
-              );
-              return;
-            }
-          }
-
-          let mac: string;
-          if ('mac' in sysInfo) mac = sysInfo.mac;
-          else if ('mic_mac' in sysInfo) mac = sysInfo.mic_mac;
-          else if ('ethernet_mac' in sysInfo) mac = sysInfo.ethernet_mac;
-          else mac = '';
-
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-          if (macAddresses && macAddresses.length > 0) {
-            if (!compareMac(mac, macAddresses)) {
-              this.log.debug(
-                `client.startDiscovery(): Filtered out: ${sysInfo.alias} [${sysInfo.deviceId}] (${mac}), allowed macs: (%j)`,
-                macAddresses,
-              );
-              return;
-            }
-          }
-
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-          if (excludeMacAddresses && excludeMacAddresses.length > 0) {
-            if (compareMac(mac, excludeMacAddresses)) {
-              this.log.debug(
-                `client.startDiscovery(): Filtered out: ${sysInfo.alias} [${sysInfo.deviceId}] (${mac}), excluded mac`,
-              );
-              return;
-            }
-          }
-
-          if (typeof filterCallback === 'function') {
-            if (!filterCallback(sysInfo)) {
-              this.log.debug(
-                `client.startDiscovery(): Filtered out: ${sysInfo.alias} [${sysInfo.deviceId}], callback`,
-              );
-              return;
-            }
-          }
-
-          this.createOrUpdateDeviceFromSysInfo({
-            sysInfo,
-            host: rinfo.address,
-            port: devicesUseDiscoveryPort ? rinfo.port : undefined,
-            breakoutChildren,
-            options: deviceOptions,
-          });
+          processDiscoveredSysInfo(sysInfo, rinfo, devicesUseDiscoveryPort);
         } catch (err) {
           this.log.debug(
             `client.startDiscovery(): Error processing response: %s\nFrom: ${rinfo.address} ${rinfo.port} Original: [%s] Decrypted: [${decryptedMsg}]`,
@@ -837,6 +957,10 @@ class Client extends EventEmitter {
       });
 
       socket.bind(port, address, () => {
+        if (this.socket !== socket) {
+          socket.close();
+          return;
+        }
         this.isSocketBound = true;
         const sockAddress = socket.address();
         this.log.debug(
@@ -855,10 +979,11 @@ class Client extends EventEmitter {
 
         this.sendDiscovery(socket, broadcast, devices ?? [], offlineTolerance);
         if (discoveryTimeout > 0) {
-          setTimeout(() => {
+          this.discoveryTimeoutTimer = setTimeout(() => {
             this.log.debug(
               'client.startDiscovery: discoveryTimeout reached, stopping discovery',
             );
+            this.discoveryTimeoutTimer = null;
             this.stopDiscovery();
           }, discoveryTimeout);
         }
@@ -951,10 +1076,15 @@ class Client extends EventEmitter {
     this.log.debug('client.stopDiscovery()');
     if (this.discoveryTimer !== null) clearInterval(this.discoveryTimer);
     this.discoveryTimer = null;
+    if (this.discoveryTimeoutTimer !== null) {
+      clearTimeout(this.discoveryTimeoutTimer);
+    }
+    this.discoveryTimeoutTimer = null;
     if (this.isSocketBound) {
       this.isSocketBound = false;
       if (this.socket != null) this.socket.close();
     }
+    this.socket = undefined;
   }
 
   private sendDiscovery(
@@ -989,6 +1119,16 @@ class Client extends EventEmitter {
         return;
       }
       socket.send(discoveryMsgBuf, 0, discoveryMsgBuf.length, 9999, address);
+      const smartDiscoveryMsg = createSmartDiscoveryProbe();
+      SMART_DISCOVERY_PORTS.forEach((smartDiscoveryPort) => {
+        socket.send(
+          smartDiscoveryMsg,
+          0,
+          smartDiscoveryMsg.length,
+          smartDiscoveryPort,
+          address,
+        );
+      });
 
       devices.forEach((d) => {
         this.log.debug('client.sendDiscovery() direct device:', d);
@@ -999,6 +1139,15 @@ class Client extends EventEmitter {
           d.port || 9999,
           d.host,
         );
+        SMART_DISCOVERY_PORTS.forEach((smartDiscoveryPort) => {
+          socket.send(
+            smartDiscoveryMsg,
+            0,
+            smartDiscoveryMsg.length,
+            smartDiscoveryPort,
+            d.host,
+          );
+        });
       });
 
       if (this.discoveryPacketSequence >= Number.MAX_VALUE) {

--- a/src/smart-discovery.ts
+++ b/src/smart-discovery.ts
@@ -1,0 +1,298 @@
+import { generateKeyPairSync, randomBytes } from 'crypto';
+
+/* eslint-disable no-bitwise */
+
+const TDP_HEADER_LENGTH = 16;
+const TDP_VERSION = 2;
+const TDP_PROBE_MESSAGE_TYPE = 0;
+const TDP_PROBE_OPCODE = 1;
+const TDP_PROBE_FLAGS = 17;
+const TDP_CRC_SEED = 0x5a6b7c8d;
+
+export const SMART_DISCOVERY_PORT = 20002;
+export const SMART_DISCOVERY_ALT_PORT = 20004;
+export const SMART_DISCOVERY_PORTS = [
+  SMART_DISCOVERY_PORT,
+  SMART_DISCOVERY_ALT_PORT,
+] as const;
+
+type SmartTransport = 'klap' | 'aes';
+
+type SmartDiscoveryHeader = {
+  version: number;
+  messageType: number;
+  opcode: number;
+  messageLength: number;
+  flags: number;
+  deviceSerial: number;
+};
+
+export type SmartDiscoveryPacket = SmartDiscoveryHeader & {
+  payload: Record<string, unknown>;
+};
+
+export type NormalizedSmartSysInfo = Record<string, unknown> & {
+  alias: string;
+  name: string;
+  deviceId: string;
+  model: string;
+  sw_ver: string;
+  hw_ver: string;
+  type: string;
+  mac: string;
+  device_on: boolean;
+  relay_state: 0 | 1;
+  mgt_encrypt_schm: Record<string, unknown>;
+};
+
+let smartDiscoveryPublicKey: string | undefined;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function getString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function getNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function getBoolean(value: unknown): boolean | undefined {
+  if (typeof value === 'boolean') return value;
+  if (value === 0) return false;
+  if (value === 1) return true;
+  return undefined;
+}
+
+function decodeBase64String(value: unknown): string | undefined {
+  const input = getString(value);
+  if (input === undefined) return undefined;
+
+  try {
+    const decoded = Buffer.from(input, 'base64');
+    if (decoded.length === 0) return undefined;
+
+    const normalizedInput = input.replace(/=+$/, '');
+    const normalizedOutput = decoded.toString('base64').replace(/=+$/, '');
+    return normalizedInput === normalizedOutput
+      ? decoded.toString('utf8')
+      : input;
+  } catch {
+    return input;
+  }
+}
+
+function getSmartDiscoveryPublicKey(): string {
+  if (smartDiscoveryPublicKey === undefined) {
+    const { publicKey } = generateKeyPairSync('rsa', {
+      modulusLength: 2048,
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    });
+    smartDiscoveryPublicKey = publicKey;
+  }
+  return smartDiscoveryPublicKey;
+}
+
+/**
+ * Calculates the IEEE CRC-32 used by the TDP v2 discovery header.
+ */
+export function calculateTdpCrc32(data: Buffer): number {
+  let crc = 0xffffffff;
+  for (let index = 0; index < data.length; index += 1) {
+    // Buffer indexing is safe for the bounded loop, but TypeScript cannot infer it.
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    crc ^= data[index]!;
+    for (let bit = 0; bit < 8; bit += 1) {
+      crc = (crc & 1) === 1 ? (crc >>> 1) ^ 0xedb88320 : crc >>> 1;
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+/**
+ * Creates the TP-Link TDP v2 probe used by current python-kasa discovery.
+ *
+ * The public key is deliberately cached for the process, matching python-kasa;
+ * every packet still has a new serial and checksum.
+ */
+export function createSmartDiscoveryProbe(): Buffer {
+  const payload = Buffer.from(
+    JSON.stringify({
+      params: { rsa_key: getSmartDiscoveryPublicKey() },
+    }),
+    'utf8',
+  );
+  const packet = Buffer.alloc(TDP_HEADER_LENGTH + payload.length);
+  packet.writeUInt8(TDP_VERSION, 0);
+  packet.writeUInt8(TDP_PROBE_MESSAGE_TYPE, 1);
+  packet.writeUInt16BE(TDP_PROBE_OPCODE, 2);
+  packet.writeUInt16BE(payload.length, 4);
+  packet.writeUInt8(TDP_PROBE_FLAGS, 6);
+  packet.writeUInt8(0, 7);
+  randomBytes(4).copy(packet, 8);
+  packet.writeUInt32BE(TDP_CRC_SEED, 12);
+  payload.copy(packet, TDP_HEADER_LENGTH);
+  packet.writeUInt32BE(calculateTdpCrc32(packet), 12);
+  return packet;
+}
+
+/**
+ * Parses the unencrypted TDP v2 outer payload. Inner encrypt_info data is not
+ * decrypted here because routing only requires the outer discovery metadata.
+ */
+export function parseSmartDiscoveryPacket(
+  message: Buffer,
+): SmartDiscoveryPacket {
+  if (message.length < TDP_HEADER_LENGTH) {
+    throw new Error(
+      'SMART discovery response is shorter than the TDP v2 header',
+    );
+  }
+
+  const version = message.readUInt8(0);
+  const messageLength = message.readUInt16BE(4);
+  if (version !== TDP_VERSION) {
+    throw new Error(`Unsupported SMART discovery TDP version: ${version}`);
+  }
+  if (message.length !== TDP_HEADER_LENGTH + messageLength) {
+    throw new Error(
+      'SMART discovery response has an invalid TDP payload length',
+    );
+  }
+
+  const receivedCrc = message.readUInt32BE(12);
+  const packetForCrc = Buffer.from(message);
+  packetForCrc.writeUInt32BE(TDP_CRC_SEED, 12);
+  if (calculateTdpCrc32(packetForCrc) !== receivedCrc) {
+    throw new Error('SMART discovery response has an invalid TDP checksum');
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(message.subarray(TDP_HEADER_LENGTH).toString('utf8'));
+  } catch {
+    throw new Error('SMART discovery response has an invalid JSON payload');
+  }
+  if (!isRecord(payload)) {
+    throw new Error('SMART discovery response JSON payload is not an object');
+  }
+
+  return {
+    version,
+    messageType: message.readUInt8(1),
+    opcode: message.readUInt16BE(2),
+    messageLength,
+    flags: message.readUInt8(6),
+    deviceSerial: message.readUInt32BE(8),
+    payload,
+  };
+}
+
+function getSafeEncryptionScheme(
+  input: unknown,
+  transport?: SmartTransport,
+  port?: number,
+): Record<string, unknown> {
+  const source = isRecord(input) ? input : {};
+  const encryptType = getString(source.encrypt_type);
+  const httpPort = getNumber(source.http_port);
+  const scheme: Record<string, unknown> = {};
+
+  if (typeof source.is_support_https === 'boolean') {
+    scheme.is_support_https = source.is_support_https;
+  }
+  if (encryptType !== undefined) {
+    scheme.encrypt_type = encryptType;
+  } else if (transport !== undefined) {
+    scheme.encrypt_type = transport.toUpperCase();
+  }
+  if (httpPort !== undefined && Number.isInteger(httpPort) && httpPort > 0) {
+    scheme.http_port = httpPort;
+  } else if (port !== undefined && Number.isInteger(port) && port > 0) {
+    scheme.http_port = port;
+  }
+  if (getNumber(source.lv) !== undefined) {
+    scheme.lv = source.lv;
+  }
+
+  return scheme;
+}
+
+/**
+ * Converts SMART get_device_info or TDP discovery metadata into the legacy
+ * Sysinfo shape expected by the existing Plug implementation.
+ */
+export function normalizeSmartSysInfo(
+  source: Record<string, unknown>,
+  options: { transport?: SmartTransport; port?: number } = {},
+): NormalizedSmartSysInfo {
+  const model = getString(source.model) ?? getString(source.device_model);
+  const deviceId = getString(source.device_id) ?? getString(source.deviceId);
+  const type = getString(source.type) ?? getString(source.device_type);
+  const mac = getString(source.mac);
+  if (
+    model === undefined ||
+    deviceId === undefined ||
+    type === undefined ||
+    mac === undefined
+  ) {
+    throw new Error('SMART device info is missing required routing fields');
+  }
+
+  const alias =
+    decodeBase64String(source.nickname) ??
+    decodeBase64String(source.device_name) ??
+    getString(source.alias) ??
+    model;
+  const deviceOn =
+    getBoolean(source.device_on) ?? getBoolean(source.relay_state) ?? false;
+  const normalized: NormalizedSmartSysInfo = {
+    alias,
+    name: alias,
+    deviceId,
+    model,
+    sw_ver:
+      getString(source.sw_ver) ??
+      getString(source.fw_ver) ??
+      getString(source.firmware_version) ??
+      '',
+    hw_ver:
+      getString(source.hw_ver) ?? getString(source.hardware_version) ?? '',
+    type,
+    mac,
+    device_on: deviceOn,
+    relay_state: deviceOn ? 1 : 0,
+    mgt_encrypt_schm: getSafeEncryptionScheme(
+      source.mgt_encrypt_schm,
+      options.transport,
+      options.port,
+    ),
+  };
+
+  [
+    'brightness',
+    'fan_speed_level',
+    'fan_sleep_mode_on',
+    'overheat_status',
+    'overheated',
+    'led_off',
+    'led_status',
+    'led_rule',
+    'auto_off_status',
+    'auto_off_remain_time',
+    'components',
+    'children',
+    'feature',
+  ].forEach((key) => {
+    if (source[key] !== undefined) {
+      normalized[key] = source[key];
+    }
+  });
+
+  return normalized;
+}

--- a/test/client.js
+++ b/test/client.js
@@ -11,6 +11,11 @@ const { default: Client } = require('../src/client');
 const { default: Device } = require('../src/device');
 const { default: Plug } = require('../src/plug');
 const { default: Bulb } = require('../src/bulb');
+const { default: SmartError } = require('../src/smart-error');
+const {
+  calculateTdpCrc32,
+  parseSmartDiscoveryPacket,
+} = require('../src/smart-discovery');
 
 const { compareMac } = require('../src/utils');
 
@@ -29,6 +34,39 @@ const validPlugDiscoveryResponse = {
     },
   },
 };
+
+const validSmartDeviceInfo = {
+  device_id: 'smart-device-id',
+  fw_ver: '1.0.0 Build 1',
+  hw_ver: '1.0',
+  mac: '00-11-22-33-44-55',
+  model: 'KS225',
+  type: 'SMART.KASASWITCH',
+  nickname: Buffer.from('SMART test device').toString('base64'),
+  device_on: true,
+  brightness: 42,
+};
+
+const validSmartDeviceInfoResponse = {
+  error_code: 0,
+  result: validSmartDeviceInfo,
+};
+
+function createSmartDiscoveryResponse(payload) {
+  const body = Buffer.from(JSON.stringify(payload), 'utf8');
+  const response = Buffer.alloc(16 + body.length);
+  response.writeUInt8(2, 0);
+  response.writeUInt8(1, 1);
+  response.writeUInt16BE(2, 2);
+  response.writeUInt16BE(body.length, 4);
+  response.writeUInt8(17, 6);
+  response.writeUInt8(0, 7);
+  response.writeUInt32BE(0x12345678, 8);
+  response.writeUInt32BE(0x5a6b7c8d, 12);
+  body.copy(response, 16);
+  response.writeUInt32BE(calculateTdpCrc32(response), 12);
+  return response;
+}
 
 describe('Client', function () {
   describe('constructor', function () {
@@ -143,12 +181,12 @@ describe('Client', function () {
       plug.closeConnection();
     });
 
-    it('should default getSysInfo port to 80 when client transport is authenticated', async function () {
+    it('should send SMART get_device_info and normalize sysinfo for an authenticated client transport', async function () {
       const client = new Client({
         defaultSendOptions: { transport: 'aes' },
       });
       const connection = {
-        send: sinon.stub().resolves(JSON.stringify(validPlugDiscoveryResponse)),
+        send: sinon.stub().resolves(JSON.stringify(validSmartDeviceInfoResponse)),
         close: sinon.stub(),
       };
       const createConnectionStub = sinon
@@ -156,19 +194,34 @@ describe('Client', function () {
         .returns(connection);
 
       const sysInfo = await client.getSysInfo('127.0.0.1');
-      expect(sysInfo).to.deep.equal(validPlugDiscoveryResponse.system.get_sysinfo);
+      expect(sysInfo).to.containSubset({
+        alias: 'SMART test device',
+        deviceId: validSmartDeviceInfo.device_id,
+        model: 'KS225',
+        sw_ver: validSmartDeviceInfo.fw_ver,
+        hw_ver: validSmartDeviceInfo.hw_ver,
+        type: 'SMART.KASASWITCH',
+        mac: validSmartDeviceInfo.mac,
+        device_on: true,
+        relay_state: 1,
+        brightness: 42,
+        mgt_encrypt_schm: { encrypt_type: 'AES', http_port: 80 },
+      });
       expect(createConnectionStub).to.have.been.calledOnce;
       expect(createConnectionStub.firstCall.args[2]).to.equal(80);
       expect(connection.send).to.have.been.calledOnce;
+      expect(JSON.parse(connection.send.firstCall.args[0])).to.deep.equal({
+        method: 'get_device_info',
+      });
       expect(connection.send.firstCall.args[1]).to.equal(80);
     });
 
-    it('should default getDevice host lookup to 80 when client transport is authenticated', async function () {
+    it('should use SMART bootstrap for getDevice when the default transport is klap', async function () {
       const client = new Client({
         defaultSendOptions: { transport: 'klap' },
       });
       const connection = {
-        send: sinon.stub().resolves(JSON.stringify(validPlugDiscoveryResponse)),
+        send: sinon.stub().resolves(JSON.stringify(validSmartDeviceInfoResponse)),
         close: sinon.stub(),
       };
       const createConnectionStub = sinon
@@ -180,8 +233,50 @@ describe('Client', function () {
       });
 
       expect(createConnectionStub.firstCall.args[2]).to.equal(80);
+      expect(JSON.parse(connection.send.firstCall.args[0])).to.deep.equal({
+        method: 'get_device_info',
+      });
       expect(device.port).to.equal(80);
       device.closeConnection();
+    });
+
+    it('should use an explicit authenticated send transport for SMART getSysInfo', async function () {
+      const client = new Client({
+        defaultSendOptions: { transport: 'tcp' },
+      });
+      const connection = {
+        send: sinon.stub().resolves(JSON.stringify(validSmartDeviceInfoResponse)),
+        close: sinon.stub(),
+      };
+      const createConnectionStub = sinon
+        .stub(client, 'createConnection')
+        .returns(connection);
+
+      const sysInfo = await client.getSysInfo('127.0.0.1', undefined, {
+        transport: 'klap',
+      });
+
+      expect(sysInfo).to.have.property('deviceId', 'smart-device-id');
+      expect(createConnectionStub.firstCall.args[0]).to.equal('klap');
+      expect(JSON.parse(connection.send.firstCall.args[0])).to.deep.equal({
+        method: 'get_device_info',
+      });
+    });
+
+    it('should surface SMART get_device_info errors as SmartError', async function () {
+      const client = new Client({
+        defaultSendOptions: { transport: 'aes' },
+      });
+      const connection = {
+        send: sinon.stub().resolves(JSON.stringify({ error_code: -1501 })),
+        close: sinon.stub(),
+      };
+      sinon.stub(client, 'createConnection').returns(connection);
+
+      await expect(client.getSysInfo('127.0.0.1')).to.be.rejectedWith(
+        SmartError,
+        'error_code: -1501 method: get_device_info',
+      );
     });
 
     it('should not override explicit transport and port with inferred values', function () {
@@ -1047,6 +1142,10 @@ describe('Client', function () {
       client.stopDiscovery();
     });
 
+    afterEach('restore discovery socket stubs', function () {
+      sinon.restore();
+    });
+
     it('should emit device-new when finding a new device', function (done) {
       client
         .startDiscovery({ discoveryInterval: 250 })
@@ -1181,6 +1280,108 @@ describe('Client', function () {
           client.stopDiscovery();
           done();
         });
+    });
+
+    it('should probe and accept TDP/20002 and TDP/20004 with its management port', function (done) {
+      const socket = new EventEmitter();
+      socket.bind = (bindPort, bindAddress, callback) => {
+        expect(bindPort).to.be.undefined;
+        expect(bindAddress).to.be.undefined;
+        callback();
+      };
+      socket.address = () => ({ address: '1.2.3.4', port: 1234, family: 'IPv4' });
+      socket.setBroadcast = sinon.fake();
+      socket.send = sinon.fake();
+      socket.close = sinon.fake();
+      sinon.replace(dgram, 'createSocket', () => socket);
+
+      const smartResponse = createSmartDiscoveryResponse({
+        error_code: 0,
+        result: {
+          device_id: 'smart-discovery-id',
+          device_type: 'SMART.KASASWITCH',
+          device_model: 'KS225(US)',
+          device_name: Buffer.from('Kitchen switch').toString('base64'),
+          mac: '00-11-22-33-44-55',
+          device_on: false,
+          brightness: 25,
+          mgt_encrypt_schm: {
+            encrypt_type: 'KLAP',
+            http_port: 80,
+            is_support_https: false,
+            lv: 2,
+          },
+        },
+      });
+
+      client = new Client();
+      client
+        .startDiscovery({
+          discoveryInterval: 10000,
+          devicesUseDiscoveryPort: true,
+          devices: [{ host: '1.2.3.5' }],
+        })
+        .once('plug-new', (plug) => {
+          try {
+            expect(plug).to.be.instanceof(Plug);
+            expect(plug.host).to.equal('1.2.3.5');
+            expect(plug.defaultSendOptions.transport).to.equal('klap');
+            expect(plug.port).to.equal(80);
+            expect(plug.sysInfo).to.containSubset({
+              alias: 'Kitchen switch',
+              deviceId: 'smart-discovery-id',
+              model: 'KS225(US)',
+              type: 'SMART.KASASWITCH',
+              device_on: false,
+              relay_state: 0,
+              brightness: 25,
+              mgt_encrypt_schm: { encrypt_type: 'KLAP', http_port: 80 },
+            });
+            socket.emit('message', smartResponse, {
+              address: '1.2.3.5',
+              port: 20004,
+            });
+          } catch (error) {
+            client.stopDiscovery();
+            done(error);
+          }
+        })
+        .once('plug-online', (plug) => {
+          try {
+            expect(plug).to.be.instanceof(Plug);
+            expect(plug.port).to.equal(80);
+            client.stopDiscovery();
+            done();
+          } catch (error) {
+            client.stopDiscovery();
+            done(error);
+          }
+        });
+
+      const sentPorts = socket.send.getCalls().map((call) => call.args[3]);
+      expect(sentPorts).to.include(9999);
+      expect(sentPorts).to.include(20002);
+      expect(sentPorts).to.include(20004);
+      const smartProbe = socket.send
+        .getCalls()
+        .find((call) => call.args[3] === 20002).args[0];
+      const smartProbeAlternate = socket.send
+        .getCalls()
+        .find((call) => call.args[3] === 20004).args[0];
+      expect(smartProbeAlternate).to.equal(smartProbe);
+      const parsedProbe = parseSmartDiscoveryPacket(smartProbe);
+      expect(parsedProbe).to.containSubset({
+        version: 2,
+        messageType: 0,
+        opcode: 1,
+        flags: 17,
+      });
+      expect(parsedProbe.payload).to.have.nested.property('params.rsa_key');
+
+      socket.emit('message', smartResponse, {
+        address: '1.2.3.5',
+        port: 20002,
+      });
     });
 
     it('should ignore invalid devices that respond without encryption', function (done) {

--- a/test/smart-discovery.js
+++ b/test/smart-discovery.js
@@ -1,0 +1,185 @@
+const assert = require('node:assert/strict');
+const { createPublicKey } = require('node:crypto');
+const dgram = require('node:dgram');
+const EventEmitter = require('node:events');
+const test = require('node:test');
+
+const { default: Client } = require('../src/client');
+const {
+  calculateTdpCrc32,
+  parseSmartDiscoveryPacket,
+} = require('../src/smart-discovery');
+
+class FakeDiscoverySocket extends EventEmitter {
+  constructor() {
+    super();
+    this.packets = [];
+  }
+
+  bind(...args) {
+    const callback = args.find((arg) => typeof arg === 'function');
+    this.bound = true;
+    callback();
+  }
+
+  address() {
+    return { address: '0.0.0.0', family: 'IPv4', port: this.port };
+  }
+
+  setBroadcast(value) {
+    this.broadcast = value;
+  }
+
+  send(message, offset, length, port, address) {
+    this.packets.push({
+      message: Buffer.from(message.subarray(offset, offset + length)),
+      port,
+      address,
+    });
+  }
+
+  close() {
+    this.closed = true;
+  }
+}
+
+function createTdpResponse(payload) {
+  const body = Buffer.from(JSON.stringify(payload), 'utf8');
+  const packet = Buffer.alloc(16 + body.length);
+  packet.writeUInt8(2, 0);
+  packet.writeUInt8(1, 1);
+  packet.writeUInt16BE(2, 2);
+  packet.writeUInt16BE(body.length, 4);
+  packet.writeUInt8(17, 6);
+  packet.writeUInt8(0, 7);
+  packet.writeUInt32BE(0x12345678, 8);
+  packet.writeUInt32BE(0x5a6b7c8d, 12);
+  body.copy(packet, 16);
+  packet.writeUInt32BE(calculateTdpCrc32(packet), 12);
+  return packet;
+}
+
+function waitForEvent(emitter, eventName) {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error(`Timed out waiting for ${eventName}`));
+    }, 500);
+    emitter.once(eventName, (value) => {
+      clearTimeout(timeout);
+      resolve(value);
+    });
+  });
+}
+
+test('uses SMART get_device_info and python-kasa-compatible TDP v2 discovery ports', async (t) => {
+  const client = new Client({
+    defaultSendOptions: { transport: 'aes' },
+  });
+  const sentRequests = [];
+  client.createConnection = () => ({
+    send: async (payload, port, host) => {
+      sentRequests.push({ payload, port, host });
+      return JSON.stringify({
+        error_code: 0,
+        result: {
+          device_id: 'smart-device-id',
+          fw_ver: '1.0.0',
+          hw_ver: '1.0',
+          mac: '00-11-22-33-44-55',
+          model: 'S500D',
+          type: 'SMART.KASASWITCH',
+          nickname: Buffer.from('SMART test device').toString('base64'),
+          device_on: true,
+        },
+      });
+    },
+    close: () => {},
+  });
+
+  const sysInfo = await client.getSysInfo('192.0.2.10');
+  assert.equal(sentRequests.length, 1);
+  assert.deepEqual(JSON.parse(sentRequests[0].payload), {
+    method: 'get_device_info',
+  });
+  assert.equal(sentRequests[0].port, 80);
+  assert.equal(sysInfo.alias, 'SMART test device');
+  assert.equal(sysInfo.relay_state, 1);
+  assert.deepEqual(sysInfo.mgt_encrypt_schm, {
+    encrypt_type: 'AES',
+    http_port: 80,
+  });
+
+  const socket = new FakeDiscoverySocket();
+  const originalCreateSocket = dgram.createSocket;
+  dgram.createSocket = () => socket;
+  t.after(() => {
+    dgram.createSocket = originalCreateSocket;
+    client.stopDiscovery();
+  });
+
+  const discovered = waitForEvent(client, 'plug-new');
+  client.startDiscovery({
+    devices: [{ host: '192.0.2.11' }],
+    devicesUseDiscoveryPort: true,
+  });
+
+  const ports = socket.packets.map((packet) => packet.port);
+  assert.ok(ports.includes(9999));
+  assert.ok(ports.includes(20002));
+  assert.ok(ports.includes(20004));
+  const smartProbe = socket.packets.find((packet) => packet.port === 20002);
+  const smartProbeAlternate = socket.packets.find(
+    (packet) => packet.port === 20004,
+  );
+  assert.deepEqual(smartProbeAlternate.message, smartProbe.message);
+  const parsedProbe = parseSmartDiscoveryPacket(smartProbe.message);
+  assert.deepEqual(
+    {
+      version: parsedProbe.version,
+      messageType: parsedProbe.messageType,
+      opcode: parsedProbe.opcode,
+      flags: parsedProbe.flags,
+    },
+    { version: 2, messageType: 0, opcode: 1, flags: 17 },
+  );
+  const rsaKey = parsedProbe.payload.params.rsa_key;
+  assert.equal(typeof rsaKey, 'string');
+  assert.equal(
+    createPublicKey(rsaKey).asymmetricKeyDetails.modulusLength,
+    2048,
+  );
+
+  const smartResponse = createTdpResponse({
+    error_code: 0,
+    result: {
+      device_id: 'discovered-smart-device',
+      fw_ver: '1.0.0',
+      hw_ver: '1.0',
+      mac: '00-11-22-33-44-66',
+      mgt_encrypt_schm: { encrypt_type: 'KLAP', http_port: 80 },
+      model: 'KS225',
+      type: 'SMART.KASASWITCH',
+      nickname: Buffer.from('Discovered SMART device').toString('base64'),
+    },
+  });
+  socket.emit('message', smartResponse, {
+    address: '192.0.2.11',
+    family: 'IPv4',
+    port: 20002,
+    size: 0,
+  });
+
+  const plug = await discovered;
+  assert.equal(plug.port, 80);
+  assert.equal(plug.defaultSendOptions.transport, 'klap');
+  assert.equal(plug.sysInfo.alias, 'Discovered SMART device');
+  const rediscovered = waitForEvent(client, 'plug-online');
+  socket.emit('message', smartResponse, {
+    address: '192.0.2.11',
+    family: 'IPv4',
+    port: 20004,
+    size: 0,
+  });
+  assert.strictEqual(await rediscovered, plug);
+  plug.closeConnection();
+});


### PR DESCRIPTION
## What changed

- bootstrap authenticated KLAP/AES devices with `get_device_info` and normalize SMART metadata into the existing sysinfo contract
- add TP-Link TDP v2 discovery on UDP ports 20002 and 20004 while retaining legacy UDP/9999 discovery
- infer the device management transport and HTTP port from `mgt_encrypt_schm`, not the UDP response port
- add regression coverage for SMART bootstrap, TDP framing/CRC, dual-port discovery, and legacy compatibility
- document the change in the changelog

## Why

Authenticated KS225, S500D, and KS240-class devices use SMART management requests and newer TDP discovery. The previous bootstrap selected port 80 but still sent the legacy `system.get_sysinfo` request, and discovery only probed UDP/9999.

## Validation

- Node.js 22.22.2: `npm run build`
- standalone TDP test: 1 passing
- full `test/client.js` suite with repository setup: 225 passing
- python-kasa fixture baseline: 9 passing
- `git diff --check`

Physical-device runtime verification was not performed.